### PR TITLE
[NOJIRA] Move path from FileProvider init to function param

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -38,10 +38,19 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:729f65378817684798e53068862397c12daffa0757abbe073f6620a560fc6fb5"
+  digest = "1:86ff4af7b6bb3d27c2e89b5ef8c139678acff1cad74a3c5235fc5af6b94fcc9e"
+  name = "github.com/stretchr/objx"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "35313a95ee26395aa17d366c71a2ccf788fa69b6"
+  version = "v0.3.0"
+
+[[projects]]
+  digest = "1:fc44ab3ee6f79e2b4c67ea294f500aa151f7b882a706eb7f3e881aba1de3a729"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
+    "mock",
     "require",
   ]
   pruneopts = "UT"
@@ -70,6 +79,7 @@
     "github.com/bitrise-io/go-utils/stringutil",
     "github.com/bitrise-io/go-utils/ziputil",
     "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/mock",
     "github.com/stretchr/testify/require",
   ]
   solver-name = "gps-cdcl"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -38,19 +38,10 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:86ff4af7b6bb3d27c2e89b5ef8c139678acff1cad74a3c5235fc5af6b94fcc9e"
-  name = "github.com/stretchr/objx"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "35313a95ee26395aa17d366c71a2ccf788fa69b6"
-  version = "v0.3.0"
-
-[[projects]]
-  digest = "1:fc44ab3ee6f79e2b4c67ea294f500aa151f7b882a706eb7f3e881aba1de3a729"
+  digest = "1:729f65378817684798e53068862397c12daffa0757abbe073f6620a560fc6fb5"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "mock",
     "require",
   ]
   pruneopts = "UT"
@@ -79,7 +70,6 @@
     "github.com/bitrise-io/go-utils/stringutil",
     "github.com/bitrise-io/go-utils/ziputil",
     "github.com/stretchr/testify/assert",
-    "github.com/stretchr/testify/mock",
     "github.com/stretchr/testify/require",
   ]
   solver-name = "gps-cdcl"

--- a/input/fileprovider.go
+++ b/input/fileprovider.go
@@ -22,30 +22,28 @@ type FileDownloader interface {
 // as a local path using `file://` scheme
 // or downloading the file to a temporary location and return the path to it.
 type FileProvider struct {
-	path           string
 	filedownloader FileDownloader
 }
 
 // NewFileProvider ...
-func NewFileProvider(path string, filedownloader FileDownloader) FileProvider {
+func NewFileProvider(filedownloader FileDownloader) FileProvider {
 	return FileProvider{
-		path:           path,
 		filedownloader: filedownloader,
 	}
 }
 
 // LocalPath ...
-func (fileProvider FileProvider) LocalPath() (string, error) {
+func (fileProvider FileProvider) LocalPath(path string) (string, error) {
 
 	var localPath string
-	if strings.HasPrefix(fileProvider.path, fileSchema) {
-		trimmedPath, err := fileProvider.trimmedFilePath()
+	if strings.HasPrefix(path, fileSchema) {
+		trimmedPath, err := fileProvider.trimmedFilePath(path)
 		if err != nil {
 			return "", err
 		}
 		localPath = trimmedPath
 	} else {
-		downloadedPath, err := fileProvider.downloadFile()
+		downloadedPath, err := fileProvider.downloadFile(path)
 		if err != nil {
 			return "", err
 		}
@@ -56,23 +54,23 @@ func (fileProvider FileProvider) LocalPath() (string, error) {
 }
 
 // Removes file:// from the begining of the path
-func (fileProvider FileProvider) trimmedFilePath() (string, error) {
-	pth := strings.TrimPrefix(fileProvider.path, fileSchema)
+func (fileProvider FileProvider) trimmedFilePath(path string) (string, error) {
+	pth := strings.TrimPrefix(path, fileSchema)
 	return pathutil.AbsPath(pth)
 }
 
-func (fileProvider FileProvider) downloadFile() (string, error) {
+func (fileProvider FileProvider) downloadFile(url string) (string, error) {
 	tmpDir, err := pathutil.NormalizedOSTempDirPath("FileProviderprovider")
 	if err != nil {
 		return "", err
 	}
 
-	fileName, err := fileProvider.fileNameFromPathURL()
+	fileName, err := fileProvider.fileNameFromPathURL(url)
 	if err != nil {
 		return "", err
 	}
 	localPath := path.Join(tmpDir, fileName)
-	if err := fileProvider.filedownloader.Get(localPath, fileProvider.path); err != nil {
+	if err := fileProvider.filedownloader.Get(localPath, url); err != nil {
 		return "", err
 	}
 
@@ -81,8 +79,8 @@ func (fileProvider FileProvider) downloadFile() (string, error) {
 
 // Returns the file's name from a URL that starts with
 // `http://` or `https://`
-func (fileProvider FileProvider) fileNameFromPathURL() (string, error) {
-	url, err := url.Parse(fileProvider.path)
+func (fileProvider FileProvider) fileNameFromPathURL(urlPath string) (string, error) {
+	url, err := url.Parse(urlPath)
 	if err != nil {
 		return "", err
 	}

--- a/input/fileprovider_test.go
+++ b/input/fileprovider_test.go
@@ -35,10 +35,10 @@ func Test_WhenTrimmedFilePathCalled_ThenExpectCorrectValue(t *testing.T) {
 
 	for _, scenario := range scenarios {
 		// Given
-		fileProvider := givenFileProvider(scenario.filePath, givenMockFileDownloader())
+		fileProvider := givenFileProvider(givenMockFileDownloader())
 
 		// When
-		actualFilePath, err := fileProvider.trimmedFilePath()
+		actualFilePath, err := fileProvider.trimmedFilePath(scenario.filePath)
 
 		// Then
 
@@ -68,10 +68,10 @@ func Test_WhenFileNameFromPathURLCalled_ThenExpectCorrectValue(t *testing.T) {
 
 	for _, scenario := range scenarios {
 		// Given
-		fileProvider := givenFileProvider(scenario.input, givenMockFileDownloader())
+		fileProvider := givenFileProvider(givenMockFileDownloader())
 
 		// When
-		actualName, err := fileProvider.fileNameFromPathURL()
+		actualName, err := fileProvider.fileNameFromPathURL(scenario.input)
 
 		// Then
 		assert.NoError(t, err)
@@ -84,10 +84,10 @@ func Test_GivenLocalFileProvided_WhenLocalPathCalled_ThenExpectLocalfilePath(t *
 	inputPath := "file:///path/tp/file/meinefile.txt"
 	expectedPath := "/path/tp/file/meinefile.txt"
 	mockFileDownloader := givenMockFileDownloader()
-	fileProvider := givenFileProvider(inputPath, mockFileDownloader)
+	fileProvider := givenFileProvider(mockFileDownloader)
 
 	// When
-	actualPath, err := fileProvider.LocalPath()
+	actualPath, err := fileProvider.LocalPath(inputPath)
 
 	// Then
 	assert.NoError(t, err)
@@ -100,10 +100,10 @@ func Test_GivenRemoteFileProvidedAndDownloadDails_WhenLocalPathCalled_ThenExpect
 	inputPath := "https://something.com/best-file-ever.bitrise"
 	expectedError := errors.New("some error")
 	mockFileDownloader := givenMockFileDownloader().GivenGetFails(expectedError)
-	fileProvider := givenFileProvider(inputPath, mockFileDownloader)
+	fileProvider := givenFileProvider(mockFileDownloader)
 
 	// When
-	actualPath, err := fileProvider.LocalPath()
+	actualPath, err := fileProvider.LocalPath(inputPath)
 
 	// Then
 	assert.EqualError(t, expectedError, err.Error())
@@ -114,18 +114,18 @@ func Test_GivenRemoteFileProvidedAndDownloadSucceeds_WhenLocalPathCalled_ThenPat
 	// Given
 	inputPath := "https://something.com/best-file-ever.bitrise"
 	mockFileDownloader := givenMockFileDownloader().GivenGetSucceed()
-	fileProvider := givenFileProvider(inputPath, mockFileDownloader)
+	fileProvider := givenFileProvider(mockFileDownloader)
 
 	// When
-	actualPath, err := fileProvider.LocalPath()
+	actualPath, err := fileProvider.LocalPath(inputPath)
 
 	// Then
 	assert.NoError(t, err)
 	assert.NotEmpty(t, actualPath)
 }
 
-func givenFileProvider(path string, filedownloader FileDownloader) FileProvider {
-	return NewFileProvider(path, filedownloader)
+func givenFileProvider(filedownloader FileDownloader) FileProvider {
+	return NewFileProvider(filedownloader)
 }
 
 func givenMockFileDownloader() *MockFileDownloader {


### PR DESCRIPTION
Move path input from init to `LocalPath` function parameter. This way `FileProvider` is reusable and could be used to handle multiple files.