### PR TITLE
Break stepconf.Parse os.Getenv dependency.

### DIFF
--- a/stepconf/stepconf.go
+++ b/stepconf/stepconf.go
@@ -175,10 +175,20 @@ func (p EnvParser) Parse(conf interface{}) error {
 	return nil
 }
 
+var defaultEnvParser *EnvParser
+
+func getDefaultEnvParser() EnvParser {
+	if defaultEnvParser == nil {
+		parser := NewDefaultEnvParser()
+		defaultEnvParser = &parser
+	}
+	return *defaultEnvParser
+}
+
 // Parse populates a struct with the retrieved values from environment variables
 // described by struct tags and applies the defined validations.
 func Parse(conf interface{}) error {
-	return NewDefaultEnvParser().Parse(conf)
+	return getDefaultEnvParser().Parse(conf)
 }
 
 func setField(field reflect.Value, value, constraint string) error {

--- a/stepconf/stepconf.go
+++ b/stepconf/stepconf.go
@@ -102,9 +102,52 @@ func parseTag(tag string) (string, string) {
 	return tag, ""
 }
 
-// Parse populates a struct with the retrieved values from environment variables
-// described by struct tags and applies the defined validations.
-func Parse(conf interface{}) error {
+// EnvProvider ...
+type EnvProvider interface {
+	Getenv(key string) string
+}
+
+// OSEnvProvider ...
+type OSEnvProvider struct{}
+
+// NewOSEnvProvider ...
+func NewOSEnvProvider() EnvProvider {
+	return OSEnvProvider{}
+}
+
+// Getenv ...
+func (p OSEnvProvider) Getenv(key string) string {
+	return os.Getenv(key)
+}
+
+// EnvParser ...
+type EnvParser struct {
+	envProvider EnvProvider
+}
+
+// EnvParserOpts ...
+type EnvParserOpts struct {
+	EnvProvider EnvProvider
+}
+
+// NewDefaultEnvParser ...
+func NewDefaultEnvParser() EnvParser {
+	return NewEnvParser(
+		EnvParserOpts{
+			EnvProvider: NewOSEnvProvider(),
+		},
+	)
+}
+
+// NewEnvParser ...
+func NewEnvParser(opts EnvParserOpts) EnvParser {
+	return EnvParser{
+		envProvider: opts.EnvProvider,
+	}
+}
+
+// Parse ...
+func (p EnvParser) Parse(conf interface{}) error {
 	c := reflect.ValueOf(conf)
 	if c.Kind() != reflect.Ptr {
 		return ErrNotStructPtr
@@ -122,7 +165,7 @@ func Parse(conf interface{}) error {
 			continue
 		}
 		key, constraint := parseTag(tag)
-		value := os.Getenv(key)
+		value := p.envProvider.Getenv(key)
 
 		if err := setField(c.Field(i), value, constraint); err != nil {
 			errs = append(errs, &ParseError{t.Field(i).Name, value, err})
@@ -139,6 +182,12 @@ func Parse(conf interface{}) error {
 	}
 
 	return nil
+}
+
+// Parse populates a struct with the retrieved values from environment variables
+// described by struct tags and applies the defined validations.
+func Parse(conf interface{}) error {
+	return NewDefaultEnvParser().Parse(conf)
 }
 
 func setField(field reflect.Value, value, constraint string) error {

--- a/stepconf/stepconf.go
+++ b/stepconf/stepconf.go
@@ -125,24 +125,15 @@ type EnvParser struct {
 	envProvider EnvProvider
 }
 
-// EnvParserOpts ...
-type EnvParserOpts struct {
-	EnvProvider EnvProvider
-}
-
 // NewDefaultEnvParser ...
 func NewDefaultEnvParser() EnvParser {
-	return NewEnvParser(
-		EnvParserOpts{
-			EnvProvider: NewOSEnvProvider(),
-		},
-	)
+	return NewEnvParser(NewOSEnvProvider())
 }
 
 // NewEnvParser ...
-func NewEnvParser(opts EnvParserOpts) EnvParser {
+func NewEnvParser(envProvider EnvProvider) EnvParser {
 	return EnvParser{
-		envProvider: opts.EnvProvider,
+		envProvider: envProvider,
 	}
 }
 


### PR DESCRIPTION
Break `stepconf.Parse`  dependency on `os.Getenv`, to facilitate unit testing.
Use-case: https://github.com/bitrise-steplib/steps-xcode-archive/pull/227/files#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eR109-R112