### PR TITLE
Multi file export update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/bitrise-io/go-steputils
 go 1.16
 
 require (
-	github.com/bitrise-io/go-utils v0.0.0-20210924090918-3e7a04d0da9d
+	github.com/bitrise-io/go-utils v0.0.0-20211110205926-af3caef627ae
+	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.7.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,5 @@
-github.com/bitrise-io/go-utils v0.0.0-20210830144330-49d11743a4fd h1:CZIAr+uoOhHS6WfsTXHi3v9CUhOXcKSyRupi9cIcRWc=
-github.com/bitrise-io/go-utils v0.0.0-20210830144330-49d11743a4fd/go.mod h1:Vi4MHnaZVL3PVoPPA/Yp6g2pzntkDH8LGiRSY7qw6KQ=
-github.com/bitrise-io/go-utils v0.0.0-20210903141333-9e20aaef213f h1:WWvOCcc44pvBs6y2rcA64a6rXrOGyEZOYU1Olh6cDdE=
-github.com/bitrise-io/go-utils v0.0.0-20210903141333-9e20aaef213f/go.mod h1:Vi4MHnaZVL3PVoPPA/Yp6g2pzntkDH8LGiRSY7qw6KQ=
-github.com/bitrise-io/go-utils v0.0.0-20210922201414-6d7c12191c72 h1:Eov/ocBE9sfljzLo7C/6GuLUtACWJpY6dRLDhTtJ2L8=
-github.com/bitrise-io/go-utils v0.0.0-20210922201414-6d7c12191c72/go.mod h1:Vi4MHnaZVL3PVoPPA/Yp6g2pzntkDH8LGiRSY7qw6KQ=
-github.com/bitrise-io/go-utils v0.0.0-20210924090918-3e7a04d0da9d h1:jU5wvShTLKSo2gYlIBoXONS2MRRL8UwiPOSqi88JF2k=
-github.com/bitrise-io/go-utils v0.0.0-20210924090918-3e7a04d0da9d/go.mod h1:Vi4MHnaZVL3PVoPPA/Yp6g2pzntkDH8LGiRSY7qw6KQ=
+github.com/bitrise-io/go-utils v0.0.0-20211110205926-af3caef627ae h1:EwjYsLc2VFthzJrWd+2wxMYH2McwB/dBwOmY3iL5Now=
+github.com/bitrise-io/go-utils v0.0.0-20211110205926-af3caef627ae/go.mod h1:Vi4MHnaZVL3PVoPPA/Yp6g2pzntkDH8LGiRSY7qw6KQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -14,9 +8,11 @@ github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrj
 github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.3.0 h1:NGXK3lHquSN08v5vWalVI/L8XU9hdzE/G6xsrze47As=
+github.com/stretchr/objx v0.3.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
@@ -30,5 +26,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/output/output.go
+++ b/output/output.go
@@ -75,30 +75,84 @@ func ExportOutputFileContentAndReturnLastNLines(content, destinationPath, envKey
 }
 
 // ZipAndExportOutput ...
-func ZipAndExportOutput(sourcePth, destinationZipPth, envKey string) error {
-	tmpDir, err := pathutil.NormalizedOSTempDirPath("__export_tmp_dir__")
+func ZipAndExportOutput(sourcePths []string, destinationZipPth, envKey string) error {
+	tmpZipFilePth, err := zipFilePath()
 	if err != nil {
 		return err
 	}
 
-	base := filepath.Base(sourcePth)
-	tmpZipFilePth := filepath.Join(tmpDir, base+".zip")
+	inputType, err := getInputType(sourcePths)
+	if err != nil {
+		return err
+	}
 
-	if exist, err := pathutil.IsDirExists(sourcePth); err != nil {
+	// We have separate zip functions for files and for a single folder and that is the main reason we cannot have mixed
+	// paths (files and also folders) in the input. It has to be either a single folder, single or multiple files. Everything
+	// else leads to an error.
+	switch inputType {
+	case singleOrMultipleFilesType:
+		err = ziputil.ZipFiles(sourcePths, tmpZipFilePth)
+	case singleFolderType:
+		err = ziputil.ZipDir(sourcePths[0], tmpZipFilePth, false)
+	case mixedFileAndFolderType:
+		return fmt.Errorf("source path list (%s) contains a mix of files and folders", sourcePths)
+	default:
+		return fmt.Errorf("source path list (%s) is empty", sourcePths)
+	}
+
+	if err != nil {
 		return err
-	} else if exist {
-		if err := ziputil.ZipDir(sourcePth, tmpZipFilePth, false); err != nil {
-			return err
-		}
-	} else if exist, err := pathutil.IsPathExists(sourcePth); err != nil {
-		return err
-	} else if exist {
-		if err := ziputil.ZipFile(sourcePth, tmpZipFilePth); err != nil {
-			return err
-		}
-	} else {
-		return fmt.Errorf("source path (%s) not exists", sourcePth)
 	}
 
 	return ExportOutputFile(tmpZipFilePth, destinationZipPth, envKey)
+}
+
+func zipFilePath() (string, error) {
+	tmpDir, err := pathutil.NormalizedOSTempDirPath("__export_tmp_dir__")
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(tmpDir, "temp-zip-file.zip"), nil
+}
+
+const (
+	singleOrMultipleFilesType = "files"
+	singleFolderType = "folder"
+	mixedFileAndFolderType = "mixed"
+)
+
+func getInputType(sourcePths []string) (string, error) {
+	var folderCount, fileCount int
+
+	for _, path := range sourcePths {
+		exist, err := pathutil.IsDirExists(path)
+		if err != nil {
+			return "", err
+		}
+
+		if exist {
+			folderCount++
+			continue
+		}
+
+		exist, err = pathutil.IsPathExists(path)
+		if err != nil {
+			return "", err
+		}
+
+		if exist {
+			fileCount++
+		}
+	}
+
+	if fileCount == len(sourcePths) {
+		return singleOrMultipleFilesType, nil
+	} else if folderCount == 1 && len(sourcePths) == 1 {
+		return singleFolderType, nil
+	} else if 0 < folderCount && 0 < fileCount {
+		return mixedFileAndFolderType, nil
+	}
+
+	return "", nil
 }


### PR DESCRIPTION
The zip function gained multi file support in the go-utils repo and this PR bring the same multi file support.

The `func ZipAndExportOutput(sourcePths []string, destinationZipPth, envKey string) error` can now export one of the following options:
- Single file
- Multiple files
- Single folder

This multi file export is being introduced because the way we find the dSYM files has changed. An application can have multiple app level dSYM (like main app, appclip, watch app, different extensions, ...) so it is no longer enough to export only one dSYM. 