### PR TITLE
Better input printing

### DIFF
--- a/stepconf/strings.go
+++ b/stepconf/strings.go
@@ -46,7 +46,7 @@ func toString(config interface{}) string {
 	str := fmt.Sprint(colorstring.Bluef("%s:\n", strings.Title(t.Name())))
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
-		var key = field.Tag.Get("env")
+		var key, _ = parseTag(field.Tag.Get("env"))
 		if key == "" {
 			key = field.Name
 		}

--- a/stepconf/strings.go
+++ b/stepconf/strings.go
@@ -16,6 +16,9 @@ func Print(config interface{}) {
 
 func valueString(v reflect.Value) string {
 	if v.Kind() != reflect.Ptr {
+		if v.IsZero() {
+			return fmt.Sprintf("<empty value>")
+		}
 		return fmt.Sprintf("%v", v.Interface())
 	}
 
@@ -42,7 +45,12 @@ func toString(config interface{}) string {
 
 	str := fmt.Sprint(colorstring.Bluef("%s:\n", strings.Title(t.Name())))
 	for i := 0; i < t.NumField(); i++ {
-		str += fmt.Sprintf("- %s: %s\n", t.Field(i).Name, valueString(v.Field(i)))
+		field := t.Field(i)
+		var key = field.Tag.Get("env")
+		if key == "" {
+			key = field.Name
+		}
+		str += fmt.Sprintf("- %s: %s\n", key, valueString(v.Field(i)))
 	}
 
 	return str

--- a/stepconf/strings.go
+++ b/stepconf/strings.go
@@ -17,7 +17,7 @@ func Print(config interface{}) {
 func valueString(v reflect.Value) string {
 	if v.Kind() != reflect.Ptr {
 		if v.IsZero() {
-			return fmt.Sprintf("<empty value>")
+			return fmt.Sprintf("<unset>")
 		}
 		return fmt.Sprintf("%v", v.Interface())
 	}

--- a/stepconf/strings_test.go
+++ b/stepconf/strings_test.go
@@ -50,13 +50,23 @@ func Test_valueString(t *testing.T) {
 	}
 }
 
-func Test_Print(t *testing.T) {
-	type printTestCfg struct {
-		MyPassword string
+func Test_PrintFormat(t *testing.T) {
+	type testConfig struct {
+		SimpleString         string `env:"simple_string"`
+		FieldWithoutEnvTag   string
+		StringThatCanBeEmpty string `env:"string_that_can_be_empty"`
+		IntThatCanBeEmpty    int    `env:"int_that_can_be_empty"`
+		BoolThatCanBeEmpty   bool   `env:"bool_that_can_be_empty"`
+		SensitiveInput       Secret `env:"sensitive_input"`
 	}
 
-	cfg := printTestCfg{
-		MyPassword: "%dorfmtpass%f",
+	cfg := testConfig{
+		SimpleString:       "simple value",
+		FieldWithoutEnvTag: "This field doesn't have a struct tag",
+		// StringThatCanBeEmpty
+		// IntThatCanBeEmpty
+		// BoolThatCanBeEmpty
+		SensitiveInput: "my secret",
 	}
 
 	reader, writer, err := os.Pipe()
@@ -73,5 +83,13 @@ func Test_Print(t *testing.T) {
 	content, err := ioutil.ReadAll(reader)
 	assert.NoError(t, err)
 
-	assert.Equal(t, toString(cfg), string(content))
+	expected := `[34;1mTestConfig:
+[0m- simple_string: simple value
+- FieldWithoutEnvTag: This field doesn't have a struct tag
+- string_that_can_be_empty: <empty value>
+- int_that_can_be_empty: <empty value>
+- bool_that_can_be_empty: <empty value>
+- sensitive_input: *****
+`
+	assert.Equal(t, expected, string(content))
 }

--- a/stepconf/strings_test.go
+++ b/stepconf/strings_test.go
@@ -58,6 +58,8 @@ func Test_PrintFormat(t *testing.T) {
 		IntThatCanBeEmpty    int    `env:"int_that_can_be_empty"`
 		BoolThatCanBeEmpty   bool   `env:"bool_that_can_be_empty"`
 		SensitiveInput       Secret `env:"sensitive_input"`
+		ValueOptionInput     string `env:"value_option_input,opt[first,second,third]"`
+		RequiredInput        string `env:"required_input,required"`
 	}
 
 	cfg := testConfig{
@@ -66,7 +68,9 @@ func Test_PrintFormat(t *testing.T) {
 		// StringThatCanBeEmpty
 		// IntThatCanBeEmpty
 		// BoolThatCanBeEmpty
-		SensitiveInput: "my secret",
+		SensitiveInput:   "my secret",
+		ValueOptionInput: "second",
+		RequiredInput:    "value",
 	}
 
 	reader, writer, err := os.Pipe()
@@ -90,6 +94,8 @@ func Test_PrintFormat(t *testing.T) {
 - int_that_can_be_empty: <empty value>
 - bool_that_can_be_empty: <empty value>
 - sensitive_input: *****
+- value_option_input: second
+- required_input: value
 `
 	assert.Equal(t, expected, string(content))
 }

--- a/stepconf/strings_test.go
+++ b/stepconf/strings_test.go
@@ -90,9 +90,9 @@ func Test_PrintFormat(t *testing.T) {
 	expected := `[34;1mTestConfig:
 [0m- simple_string: simple value
 - FieldWithoutEnvTag: This field doesn't have a struct tag
-- string_that_can_be_empty: <empty value>
-- int_that_can_be_empty: <empty value>
-- bool_that_can_be_empty: <empty value>
+- string_that_can_be_empty: <unset>
+- int_that_can_be_empty: <unset>
+- bool_that_can_be_empty: <unset>
 - sensitive_input: *****
 - value_option_input: second
 - required_input: value


### PR DESCRIPTION
### Context

`stepconf.Print()` is used by every step to print the step input keys and values to the build log. However, the printed key is the name of the struct field instead of the key defined in `step.yml`. This is confusing not just because of the casing (`LogFormatter` vs `log_formatter`) but because sometimes the field has a slightly different name (`ExportMethod` vs `distribution_method`)

### Changes

- Look up the step.yml key (defined as struct tags) if possible, and use the field name otherwise
- When the field value is empty, print `key: <empty value>`
- Add tests

### Before

```
Inputs:
- ExportMethod: development
- UploadBitcode: true
- CompileBitcode: true
- ICloudContainerEnvironment:
- ExportDevelopmentTeam:
- ExportOptionsPlistContent:
- LogFormatter: xcodebuild
- ProjectPath: ./_tmp/ios-simple-objc/ios-simple-objc.xcodeproj
- Scheme: ios-simple-objc
- Configuration:
- OutputDir: /var/folders/ct/17xjfvhn1wx1vtkm_ppj10t40000gp/T/deploy228288972
- PerformCleanAction: false
- XcodebuildOptions:
- XcconfigContent: COMPILER_INDEX_STORE_ENABLE = NO
CODE_SIGN_IDENTITY = iPhone Developer: Dev Portal Bot Bitrise

- ExportAllDsyms: true
- ArtifactName:
- VerboseLog: true
- CacheLevel: swift_packages
- CodeSigningAuthSource: off
- CertificateURLList:
- CertificatePassphraseList:
- KeychainPath: /Users/oliverfalvai/Library/Keychains/login.keychain
- KeychainPassword:
- RegisterTestDevices: false
- MinDaysProfileValid: 0
- BuildURL:
- BuildAPIToken:
```


### After

```
Inputs:
- distribution_method: development
- upload_bitcode: true
- compile_bitcode: true
- icloud_container_environment: <empty value>
- export_development_team: <empty value>
- export_options_plist_content: <empty value>
- log_formatter: xcodebuild
- project_path: ./_tmp/ios-simple-objc/ios-simple-objc.xcodeproj
- scheme: ios-simple-objc
- configuration: <empty value>
- output_dir: /var/folders/ct/17xjfvhn1wx1vtkm_ppj10t40000gp/T/deploy297809068
- perform_clean_action: <empty value>
- xcodebuild_options: <empty value>
- xcconfig_content: COMPILER_INDEX_STORE_ENABLE = NO
CODE_SIGN_IDENTITY = iPhone Developer: Dev Portal Bot Bitrise

- export_all_dsyms: true
- artifact_name: <empty value>
- verbose_log: true
- cache_level: swift_packages
- automatic_code_signing: off
- certificate_url_list: <empty value>
- passphrase_list: <empty value>
- keychain_path: /Users/oliverfalvai/Library/Keychains/login.keychain
- keychain_password: <empty value>
- register_test_devices: <empty value>
- min_profile_validity: <empty value>
- BITRISE_BUILD_URL: <empty value>
- BITRISE_BUILD_API_TOKEN: <empty value>
```