### PR TITLE
Fix printing false and 0 input values

### DIFF
--- a/stepconf/strings.go
+++ b/stepconf/strings.go
@@ -16,7 +16,7 @@ func Print(config interface{}) {
 
 func valueString(v reflect.Value) string {
 	if v.Kind() != reflect.Ptr {
-		if v.IsZero() {
+		if v.Kind() == reflect.String && v.Len() == 0 {
 			return fmt.Sprintf("<unset>")
 		}
 		return fmt.Sprintf("%v", v.Interface())

--- a/stepconf/strings_test.go
+++ b/stepconf/strings_test.go
@@ -91,8 +91,8 @@ func Test_PrintFormat(t *testing.T) {
 [0m- simple_string: simple value
 - FieldWithoutEnvTag: This field doesn't have a struct tag
 - string_that_can_be_empty: <unset>
-- int_that_can_be_empty: <unset>
-- bool_that_can_be_empty: <unset>
+- int_that_can_be_empty: 0
+- bool_that_can_be_empty: false
 - sensitive_input: *****
 - value_option_input: second
 - required_input: value


### PR DESCRIPTION
`reflect.Value.IsZero()` returns true for `false` and `0` values, so those input values are printed as `<unset>` at the moment.

There is no way to differentiate undefined boolean and numeric inputs from `false` and `0`, but it's still better to print undefined inputs as `false` and `0` than printing explicit `false` and `0` input values as `<unset>`