### PR TITLE
Added support for asdf version manager.

### DIFF
--- a/ruby/environment.go
+++ b/ruby/environment.go
@@ -17,6 +17,7 @@ const (
 	systemRubyPth  = "/usr/bin/ruby"
 	brewRubyPth    = "/usr/local/bin/ruby"
 	brewRubyPthAlt = "/usr/local/opt/ruby/bin/ruby"
+	asdfRubyPath   = "$HOME/.asdf/shims/ruby"
 )
 
 // InstallType ...
@@ -33,6 +34,8 @@ const (
 	RVMRuby
 	// RbenvRuby ...
 	RbenvRuby
+	// ASDFRuby ...
+	ASDFRuby
 )
 
 // Environment ...
@@ -113,6 +116,8 @@ func rubyInstallType(cmdLocator env.CommandLocator) InstallType {
 		installType = RVMRuby
 	} else if _, err := cmdLocator.LookPath("rbenv"); err == nil {
 		installType = RbenvRuby
+	} else if _, err := cmdLocator.LookPath("asdf"); err == nil {
+		installType = ASDFRuby
 	}
 
 	return installType

--- a/ruby/mocks/CommandLocator.go
+++ b/ruby/mocks/CommandLocator.go
@@ -1,0 +1,27 @@
+package mocks
+
+import "github.com/stretchr/testify/mock"
+
+type CommandLocator struct {
+	mock.Mock
+}
+
+func (_m *CommandLocator) LookPath(file string) (string, error) {
+	ret := _m.Called(file)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(file)
+	} else {
+		r0, _ = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(file)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}


### PR DESCRIPTION
When executing the Run_Simulator_Tests workflow in [this repo](https://github.com/bitrise-io/Bitrise-iOS-Cocoapods-Sample) via the CLI, I encountered this error:
```Installing cocoapods
Checking cocoapods 1.11.3 gem
Failed to check if cocoapods 1.11.3 installed, error: unknown ruby installation type
```
After checking Google, I found [this thread](https://github.com/bitrise-io/go-utils/issues/111), which is exactly the issue I have, since I'm using asdf as a Ruby version manager.

This PR addresses this by adding a new type Ruby Install type, as well as a suite of tests that validate this behavior. 
