### PR TITLE
Cache key template parsing

### DIFF
--- a/cache/keytemplate/keytemplate.go
+++ b/cache/keytemplate/keytemplate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 )
 
+// Model ...
 type Model struct {
 	envRepo env.Repository
 	logger  log.Logger
@@ -17,6 +18,7 @@ type Model struct {
 	arch    string
 }
 
+// BuildContext contains metadata about the build that gets exposed to the template
 type BuildContext struct {
 	Workflow   string
 	Branch     string
@@ -31,6 +33,7 @@ type templateInventory struct {
 	CommitHash string
 }
 
+// NewModel ...
 func NewModel(envRepo env.Repository, logger log.Logger) Model {
 	return Model{
 		envRepo: envRepo,

--- a/cache/keytemplate/keytemplate.go
+++ b/cache/keytemplate/keytemplate.go
@@ -71,7 +71,11 @@ func (m Model) Evaluate(key string, buildContext BuildContext) (string, error) {
 }
 
 func (m Model) getEnvVar(key string) string {
-	return m.envRepo.Get(key)
+	value := m.envRepo.Get(key)
+	if value == "" {
+		m.logger.Warnf("Environment variable %s is empty", key)
+	}
+	return value
 }
 
 func (m Model) validateInventory(inventory templateInventory) {

--- a/cache/keytemplate/keytemplate.go
+++ b/cache/keytemplate/keytemplate.go
@@ -1,0 +1,84 @@
+package keytemplate
+
+import (
+	"bytes"
+	"fmt"
+	"runtime"
+	"text/template"
+
+	"github.com/bitrise-io/go-utils/v2/env"
+	"github.com/bitrise-io/go-utils/v2/log"
+)
+
+type Model struct {
+	envRepo env.Repository
+	logger  log.Logger
+	os      string
+	arch    string
+}
+
+type BuildContext struct {
+	Workflow   string
+	Branch     string
+	CommitHash string
+}
+
+type templateInventory struct {
+	OS         string
+	Arch       string
+	Workflow   string
+	Branch     string
+	CommitHash string
+}
+
+func NewModel(envRepo env.Repository, logger log.Logger) Model {
+	return Model{
+		envRepo: envRepo,
+		logger:  logger,
+		os:      runtime.GOOS,
+		arch:    runtime.GOARCH,
+	}
+}
+
+// Evaluate returns the final string from a key template and the provided build context
+func (m Model) Evaluate(key string, buildContext BuildContext) (string, error) {
+	funcMap := template.FuncMap{
+		"getenv": m.getEnvVar,
+	}
+
+	tmpl, err := template.New("").Funcs(funcMap).Parse(key)
+	if err != nil {
+		return "", fmt.Errorf("invalid template: %w", err)
+	}
+
+	inventory := templateInventory{
+		OS:         m.os,
+		Arch:       m.arch,
+		Workflow:   buildContext.Workflow,
+		Branch:     buildContext.Branch,
+		CommitHash: buildContext.CommitHash,
+	}
+	m.validateInventory(inventory)
+
+	resultBuffer := bytes.Buffer{}
+	if err := tmpl.Execute(&resultBuffer, inventory); err != nil {
+		return "", err
+	}
+	return resultBuffer.String(), nil
+}
+
+func (m Model) getEnvVar(key string) string {
+	return m.envRepo.Get(key)
+}
+
+func (m Model) validateInventory(inventory templateInventory) {
+	m.warnIfEmpty("Workflow", inventory.Workflow)
+	m.warnIfEmpty("Branch", inventory.Branch)
+	m.warnIfEmpty("CommitHash", inventory.CommitHash)
+}
+
+func (m Model) warnIfEmpty(name, value string) {
+	if value == "" {
+		m.logger.Warnf("Template variable .%s is not defined", name)
+	}
+}

--- a/cache/keytemplate/keytemplate_test.go
+++ b/cache/keytemplate/keytemplate_test.go
@@ -109,9 +109,8 @@ func (repo envRepository) Get(key string) string {
 	value, ok := repo.envVars[key]
 	if ok {
 		return value
-	} else {
-		return ""
 	}
+	return ""
 }
 
 func (repo envRepository) Set(key, value string) error {

--- a/cache/keytemplate/keytemplate_test.go
+++ b/cache/keytemplate/keytemplate_test.go
@@ -1,0 +1,133 @@
+package keytemplate
+
+import (
+	"testing"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+)
+
+var buildContext = BuildContext{
+	Workflow:   "primary",
+	Branch:     "PLANG-2007-key-template–parsing",
+	CommitHash: "8d722f4cc4e70373bd0b42139fa428d43e0527f0",
+}
+
+func TestEvaluate(t *testing.T) {
+	type args struct {
+		input        string
+		buildContext BuildContext
+		envVars      map[string]string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Static key",
+			args: args{
+				input:        "my-cache-key",
+				buildContext: buildContext,
+			},
+			want:    "my-cache-key",
+			wantErr: false,
+		},
+		{
+			name: "Key with variables",
+			args: args{
+				input:        "npm-cache-{{ .OS }}-{{ .Arch }}-{{ .Branch }}",
+				buildContext: buildContext,
+			},
+			want:    "npm-cache-darwin-arm64-PLANG-2007-key-template–parsing",
+			wantErr: false,
+		},
+		{
+			name: "Key with missing variables",
+			args: args{
+				input: "npm-cache-{{ .Branch }}-{{ .CommitHash }}-v1",
+				buildContext: BuildContext{
+					Workflow:   "primary",
+					Branch:     "",
+					CommitHash: "",
+				},
+			},
+			want:    "npm-cache---v1",
+			wantErr: false,
+		},
+		{
+			name: "Key with env vars",
+			args: args{
+				input:        "npm-cache-{{ getenv \"BUILD_TYPE\" }}",
+				buildContext: buildContext,
+				envVars: map[string]string{
+					"BUILD_TYPE":  "release",
+					"ANOTHER_ENV": "false",
+				},
+			},
+			want:    "npm-cache-release",
+			wantErr: false,
+		},
+		{
+			name: "Key with missing env var",
+			args: args{
+				input:        "npm-cache-{{ getenv \"BUILD_TYPE\" }}",
+				buildContext: buildContext,
+				envVars: map[string]string{
+					"ANOTHER_ENV": "false",
+				},
+			},
+			want:    "npm-cache-",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := Model{
+				envRepo: envRepository{envVars: tt.args.envVars},
+				logger:  log.NewLogger(),
+				os:      "darwin",
+				arch:    "arm64",
+			}
+			got, err := model.Evaluate(tt.args.input, tt.args.buildContext)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Evaluate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Evaluate() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type envRepository struct {
+	envVars map[string]string
+}
+
+func (repo envRepository) Get(key string) string {
+	value, ok := repo.envVars[key]
+	if ok {
+		return value
+	} else {
+		return ""
+	}
+}
+
+func (repo envRepository) Set(key, value string) error {
+	repo.envVars[key] = value
+	return nil
+}
+
+func (repo envRepository) Unset(key string) error {
+	repo.envVars[key] = ""
+	return nil
+}
+
+func (repo envRepository) List() []string {
+	var values []string
+	for _, v := range repo.envVars {
+		values = append(values, v)
+	}
+	return values
+}


### PR DESCRIPTION
### Context

Introduce a new package to handle cache key template parsing. This will be a shared dependency of the `save-cache` and `restore-cache` steps.

See the test cases for a few practical examples.

Matching PR in a step: https://github.com/bitrise-steplib/bitrise-step-save-cache/pull/4

### Changes

- Implement template parsing on top of the `text/template` package
- Expose a few template variables and functions


### Out of scope

Implementing the `checksum` template function is out of scope for this PR, that will come later.
