### PR TITLE
Add `checksum` template function

### DIFF
--- a/cache/keytemplate/checksum.go
+++ b/cache/keytemplate/checksum.go
@@ -1,0 +1,86 @@
+package keytemplate
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+)
+
+// checksum returns a hex-encoded SHA-256 checksum of one or multiple files. Each file path can contain glob patterns,
+// including "doublestar" patterns (such as `**/*.gradle`).
+// Errors are logged as warnings and an empty string is returned in that case.
+func (m Model) checksum(paths ...string) string {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		m.logger.Errorf(err.Error())
+		return ""
+	}
+	files := m.evaluateGlobPatterns(workingDir, paths)
+	m.logger.Debugf("Files included in checksum:")
+	for _, path := range files {
+		m.logger.Debugf("- %s", path)
+	}
+
+	if len(files) == 0 {
+		m.logger.Warnf("No files to include in the checksum")
+		return ""
+	} else if len(files) == 1 {
+		checksum, err := checksumOfFile(files[0])
+		if err != nil {
+			m.logger.Warnf("Error while computing checksum %s: %s", files[0], err)
+			return ""
+		}
+		return hex.EncodeToString(checksum)
+	}
+
+	finalChecksum := sha256.New()
+	sort.Strings(files)
+	for _, path := range files {
+		checksum, err := checksumOfFile(path)
+		if err != nil {
+			m.logger.Warnf("Error while hashing %s: %s", path, err)
+			continue
+		}
+
+		finalChecksum.Write(checksum)
+	}
+
+	return hex.EncodeToString(finalChecksum.Sum(nil))
+}
+
+func (m Model) evaluateGlobPatterns(workingDir string, paths []string) []string {
+	var finalPaths []string
+
+	for _, path := range paths {
+		if strings.Contains(path, "*") {
+			matches, err := doublestar.Glob(os.DirFS(workingDir), path)
+			if matches == nil {
+				m.logger.Warnf("No match for pattern: %s", path)
+				continue
+			}
+			if err != nil {
+				m.logger.Warnf("Error in pattern '%s': %s", path, err)
+				continue
+			}
+			finalPaths = append(finalPaths, matches...)
+		} else {
+			finalPaths = append(finalPaths, path)
+		}
+	}
+
+	return finalPaths
+}
+
+func checksumOfFile(path string) ([]byte, error) {
+	hash := sha256.New()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	hash.Write(b)
+	return hash.Sum(nil), nil
+}

--- a/cache/keytemplate/checksum.go
+++ b/cache/keytemplate/checksum.go
@@ -12,6 +12,7 @@ import (
 
 // checksum returns a hex-encoded SHA-256 checksum of one or multiple files. Each file path can contain glob patterns,
 // including "doublestar" patterns (such as `**/*.gradle`).
+// The path list is sorted alphabetically to produce consistent output.
 // Errors are logged as warnings and an empty string is returned in that case.
 func (m Model) checksum(paths ...string) string {
 	workingDir, err := os.Getwd()

--- a/cache/keytemplate/checksum_test.go
+++ b/cache/keytemplate/checksum_test.go
@@ -1,0 +1,72 @@
+package keytemplate
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+)
+
+func TestChecksum(t *testing.T) {
+	tests := []struct {
+		name  string
+		paths []string
+		want  string
+	}{
+		{
+			name:  "Single file",
+			paths: []string{"testdata/package-lock.json"},
+			want:  "c048b369d6e8b0616971ccc5aa33df2910d6b78c408041a8d6b11cfb8d38b29e",
+		},
+		{
+			name:  "No file",
+			paths: []string{},
+			want:  "",
+		},
+		{
+			name:  "Invalid file path",
+			paths: []string{"not_going_to_work"},
+			want:  "",
+		},
+		{
+			name:  "File list",
+			paths: []string{"testdata/package-lock.json", "testdata/build.gradle"},
+			want:  "3332b32f95e07206f0915399e16444d6cbfb59dfb1f821b51a67ea3270f758d7",
+		},
+		{
+			name:  "File list, one file is invalid",
+			paths: []string{"testdata/package-lock.json", "testdata/build.gradle", "invalid"},
+			want:  "3332b32f95e07206f0915399e16444d6cbfb59dfb1f821b51a67ea3270f758d7",
+		},
+		{
+			name:  "Single glob star",
+			paths: []string{"testdata/*.gradle"},
+			want:  "db094ffe3aea59fc48766cb408894ada1c67dbd355d25085729394df82fb1eda",
+		},
+		{
+			name:  "Double glob star",
+			paths: []string{"testdata/**/*.gradle"},
+			want:  "3a6e11679515ce19ef1728549588e672e76b00c9b6855ed1d33d0305ec5ecad3",
+		},
+		{
+			name:  "Multiple glob stars",
+			paths: []string{"testdata/**/*.gradle*"},
+			want:  "563cf037f336453ee1888c3dcbe1c687ebeb6c593d4d0bd57ccc5fc49daa3951",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := log.NewLogger()
+			logger.EnableDebugLog(true)
+			m := Model{
+				envRepo: envRepository{},
+				logger:  logger,
+				os:      runtime.GOOS,
+				arch:    runtime.GOARCH,
+			}
+			if got := m.checksum(tt.paths...); got != tt.want {
+				t.Errorf("checksum() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cache/keytemplate/keytemplate.go
+++ b/cache/keytemplate/keytemplate.go
@@ -46,7 +46,8 @@ func NewModel(envRepo env.Repository, logger log.Logger) Model {
 // Evaluate returns the final string from a key template and the provided build context
 func (m Model) Evaluate(key string, buildContext BuildContext) (string, error) {
 	funcMap := template.FuncMap{
-		"getenv": m.getEnvVar,
+		"getenv":   m.getEnvVar,
+		"checksum": m.checksum,
 	}
 
 	tmpl, err := template.New("").Funcs(funcMap).Parse(key)

--- a/cache/keytemplate/keytemplate_test.go
+++ b/cache/keytemplate/keytemplate_test.go
@@ -58,7 +58,7 @@ func TestEvaluate(t *testing.T) {
 		{
 			name: "Key with env vars",
 			args: args{
-				input:        "npm-cache-{{ getenv \"BUILD_TYPE\" }}",
+				input:        `npm-cache-{{ getenv "BUILD_TYPE" }}`,
 				buildContext: buildContext,
 				envVars: map[string]string{
 					"BUILD_TYPE":  "release",
@@ -71,13 +71,31 @@ func TestEvaluate(t *testing.T) {
 		{
 			name: "Key with missing env var",
 			args: args{
-				input:        "npm-cache-{{ getenv \"BUILD_TYPE\" }}",
+				input:        `npm-cache-{{ getenv "BUILD_TYPE" }}`,
 				buildContext: buildContext,
 				envVars: map[string]string{
 					"ANOTHER_ENV": "false",
 				},
 			},
 			want:    "npm-cache-",
+			wantErr: false,
+		},
+		{
+			name: "Key with file checksum",
+			args: args{
+				input:        `gradle-cache-{{ checksum "testdata/**/*.gradle*" }}`,
+				buildContext: buildContext,
+			},
+			want:    "gradle-cache-563cf037f336453ee1888c3dcbe1c687ebeb6c593d4d0bd57ccc5fc49daa3951",
+			wantErr: false,
+		},
+		{
+			name: "Key with multiple file checksum params",
+			args: args{
+				input:        `gradle-cache-{{ checksum "testdata/**/*.gradle*" "testdata/package-lock.json" }}`,
+				buildContext: buildContext,
+			},
+			want:    "gradle-cache-f7a92b852d03a958a99e8c04b831d1e709ee2e9b7a00d851317e66d617188a8b",
 			wantErr: false,
 		},
 	}

--- a/cache/keytemplate/testdata/app/build.gradle
+++ b/cache/keytemplate/testdata/app/build.gradle
@@ -1,0 +1,1 @@
+dummy nested file, used for hashing tests

--- a/cache/keytemplate/testdata/build.gradle
+++ b/cache/keytemplate/testdata/build.gradle
@@ -1,0 +1,1 @@
+dummy Gradle file, used for hashing tests

--- a/cache/keytemplate/testdata/build.gradle.kts
+++ b/cache/keytemplate/testdata/build.gradle.kts
@@ -1,0 +1,1 @@
+dummy Gradle KotlinScript file, used for checksum tests

--- a/cache/keytemplate/testdata/package-lock.json
+++ b/cache/keytemplate/testdata/package-lock.json
@@ -1,0 +1,1 @@
+dummy NPM lockfile, used for hashing tests

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/bitrise-io/go-steputils v1.0.1
 	github.com/bitrise-io/go-utils v1.0.1
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.1
+	github.com/bmatcuk/doublestar/v4 v4.2.0
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/bitrise-io/go-utils v1.0.1 h1:e7mepVBkVN1DXRPESNXb0djEw6bxB6B93p/Q74z
 github.com/bitrise-io/go-utils v1.0.1/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.1 h1:4PBBhTUl6NthNJCTCexe/22e/crE6FTmYfcMAM/UirY=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.1/go.mod h1:sy+Ir1X8P3tAAx/qU/r+hqDjHDcrMjIzDEvId1wqNc4=
+github.com/bmatcuk/doublestar/v4 v4.2.0 h1:Qu+u9wR3Vd89LnlLMHvnZ5coJMWKQamqdz9/p5GNthA=
+github.com/bmatcuk/doublestar/v4 v4.2.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
### Context

This PR improves the cache key template handling added in #50, by implementing the `checksum` template function.

### Changes

- Compute SHA-256 checksums of one or more files
- Multiple files are handled by feeding the raw bytes into the hash algo sequentially (after sorting the file paths)
- Add support for glob patterns, including "doublestar" (`**/*.gradle`), using https://github.com/bmatcuk/doublestar

See tests for actual pattern examples.