### PR TITLE
Add support for asdf-managed Ruby installs

### DIFF
--- a/ruby/command.go
+++ b/ruby/command.go
@@ -64,6 +64,9 @@ func (f commandFactory) CreateGemInstall(gem, version string, enablePrerelease, 
 	if f.installType == RbenvRuby {
 		cmd := f.Create("rbenv", []string{"rehash"}, nil)
 		cmds = append(cmds, cmd)
+	} else if f.installType == ASDFRuby {
+		cmd := f.Create("asdf", []string{"reshim", "ruby"}, nil)
+		cmds = append(cmds, cmd)
 	}
 
 	return cmds
@@ -76,6 +79,9 @@ func (f commandFactory) CreateGemUpdate(gem string, opts *command.Opts) []comman
 
 	if f.installType == RbenvRuby {
 		cmd := f.Create("rbenv", []string{"rehash"}, nil)
+		cmds = append(cmds, cmd)
+	} else if f.installType == ASDFRuby {
+		cmd := f.Create("asdf", []string{"reshim", "ruby"}, nil)
 		cmds = append(cmds, cmd)
 	}
 

--- a/ruby/command_test.go
+++ b/ruby/command_test.go
@@ -17,6 +17,7 @@ func Test_sudoNeeded(t *testing.T) {
 		require.Equal(t, false, sudoNeeded(BrewRuby, "ls"))
 		require.Equal(t, false, sudoNeeded(RVMRuby, "ls"))
 		require.Equal(t, false, sudoNeeded(RbenvRuby, "ls"))
+		require.Equal(t, false, sudoNeeded(ASDFRuby, "ls"))
 	}
 
 	t.Log("sudo needed for SystemRuby in case of gem list management command")
@@ -26,12 +27,14 @@ func Test_sudoNeeded(t *testing.T) {
 		require.Equal(t, false, sudoNeeded(BrewRuby, "gem", "install", "fastlane"))
 		require.Equal(t, false, sudoNeeded(RVMRuby, "gem", "install", "fastlane"))
 		require.Equal(t, false, sudoNeeded(RbenvRuby, "gem", "install", "fastlane"))
+		require.Equal(t, false, sudoNeeded(ASDFRuby, "gem", "install", "fastlane"))
 
 		require.Equal(t, false, sudoNeeded(Unknown, "gem", "uninstall", "fastlane"))
 		require.Equal(t, true, sudoNeeded(SystemRuby, "gem", "uninstall", "fastlane"))
 		require.Equal(t, false, sudoNeeded(BrewRuby, "gem", "uninstall", "fastlane"))
 		require.Equal(t, false, sudoNeeded(RVMRuby, "gem", "uninstall", "fastlane"))
 		require.Equal(t, false, sudoNeeded(RbenvRuby, "gem", "uninstall", "fastlane"))
+		require.Equal(t, false, sudoNeeded(ASDFRuby, "gem", "uninstall", "fastlane"))
 
 		require.Equal(t, false, sudoNeeded(Unknown, "bundle", "install"))
 		require.Equal(t, false, sudoNeeded(Unknown, "bundle", "_2.0.2_", "install"))
@@ -41,6 +44,7 @@ func Test_sudoNeeded(t *testing.T) {
 		require.Equal(t, false, sudoNeeded(BrewRuby, "bundle", "install"))
 		require.Equal(t, false, sudoNeeded(RVMRuby, "bundle", "install"))
 		require.Equal(t, false, sudoNeeded(RbenvRuby, "bundle", "install"))
+		require.Equal(t, false, sudoNeeded(ASDFRuby, "bundle", "install"))
 
 		require.Equal(t, false, sudoNeeded(Unknown, "bundle", "update"))
 		require.Equal(t, false, sudoNeeded(Unknown, "bundle", "_2.0.2_", "update"))
@@ -49,6 +53,7 @@ func Test_sudoNeeded(t *testing.T) {
 		require.Equal(t, false, sudoNeeded(BrewRuby, "bundle", "update"))
 		require.Equal(t, false, sudoNeeded(RVMRuby, "bundle", "update"))
 		require.Equal(t, false, sudoNeeded(RbenvRuby, "bundle", "update"))
+		require.Equal(t, false, sudoNeeded(ASDFRuby, "bundle", "update"))
 	}
 }
 

--- a/ruby/environment.go
+++ b/ruby/environment.go
@@ -17,6 +17,7 @@ const (
 	systemRubyPth  = "/usr/bin/ruby"
 	brewRubyPth    = "/usr/local/bin/ruby"
 	brewRubyPthAlt = "/usr/local/opt/ruby/bin/ruby"
+	asdfRubyPath   = "$HOME/.asdf/shims/ruby"
 )
 
 // InstallType ...
@@ -33,6 +34,8 @@ const (
 	RVMRuby
 	// RbenvRuby ...
 	RbenvRuby
+	// ASDFRuby ...
+	ASDFRuby
 )
 
 // Environment ...
@@ -113,6 +116,8 @@ func rubyInstallType(cmdLocator env.CommandLocator) InstallType {
 		installType = RVMRuby
 	} else if _, err := cmdLocator.LookPath("rbenv"); err == nil {
 		installType = RbenvRuby
+	} else if _, err := cmdLocator.LookPath("asdf"); err == nil {
+		installType = ASDFRuby
 	}
 
 	return installType

--- a/ruby/environment.go
+++ b/ruby/environment.go
@@ -83,7 +83,12 @@ func rubyInstallType(cmdLocator env.CommandLocator) InstallType {
 	} else if _, err := cmdLocator.LookPath("rbenv"); err == nil {
 		installType = RbenvRuby
 	} else if _, err := cmdLocator.LookPath("asdf"); err == nil {
-		installType = ASDFRuby
+		// asdf doesn't store its installs in a definite location,
+		// but it does store its shims in a 'shims' directory, which
+		// is what we get when we'll get from the `LookPath` call above.
+		if strings.Contains(pth, "shims/ruby") {
+			installType = ASDFRuby
+		}
 	}
 
 	return installType

--- a/ruby/environment.go
+++ b/ruby/environment.go
@@ -17,7 +17,6 @@ const (
 	systemRubyPth  = "/usr/bin/ruby"
 	brewRubyPth    = "/usr/local/bin/ruby"
 	brewRubyPthAlt = "/usr/local/opt/ruby/bin/ruby"
-	asdfRubyPath   = "$HOME/.asdf/shims/ruby"
 )
 
 // InstallType ...
@@ -43,6 +42,7 @@ type Environment interface {
 	RubyInstallType() InstallType
 	IsGemInstalled(gem, version string) (bool, error)
 	IsSpecifiedRbenvRubyInstalled(workdir string) (bool, string, error)
+	IsSpecifiedASDFRubyInstalled(workdir string) (bool, string, error)
 }
 
 type environment struct {
@@ -63,6 +63,30 @@ func NewEnvironment(factory CommandFactory, cmdLocator env.CommandLocator, logge
 // RubyInstallType returns which version manager was used for the ruby install
 func (m environment) RubyInstallType() InstallType {
 	return rubyInstallType(m.cmdLocator)
+}
+
+func rubyInstallType(cmdLocator env.CommandLocator) InstallType {
+	pth, err := cmdLocator.LookPath("ruby")
+	if err != nil {
+		return Unknown
+	}
+
+	installType := Unknown
+	if pth == systemRubyPth {
+		installType = SystemRuby
+	} else if pth == brewRubyPth {
+		installType = BrewRuby
+	} else if pth == brewRubyPthAlt {
+		installType = BrewRuby
+	} else if _, err := cmdLocator.LookPath("rvm"); err == nil {
+		installType = RVMRuby
+	} else if _, err := cmdLocator.LookPath("rbenv"); err == nil {
+		installType = RbenvRuby
+	} else if _, err := cmdLocator.LookPath("asdf"); err == nil {
+		installType = ASDFRuby
+	}
+
+	return installType
 }
 
 func (m environment) IsGemInstalled(gem, version string) (bool, error) {
@@ -99,36 +123,13 @@ func (m environment) IsSpecifiedRbenvRubyInstalled(workdir string) (bool, string
 	return isSpecifiedRbenvRubyInstalled(out)
 }
 
-func rubyInstallType(cmdLocator env.CommandLocator) InstallType {
-	pth, err := cmdLocator.LookPath("ruby")
-	if err != nil {
-		return Unknown
-	}
-
-	installType := Unknown
-	if pth == systemRubyPth {
-		installType = SystemRuby
-	} else if pth == brewRubyPth {
-		installType = BrewRuby
-	} else if pth == brewRubyPthAlt {
-		installType = BrewRuby
-	} else if _, err := cmdLocator.LookPath("rvm"); err == nil {
-		installType = RVMRuby
-	} else if _, err := cmdLocator.LookPath("rbenv"); err == nil {
-		installType = RbenvRuby
-	} else if _, err := cmdLocator.LookPath("asdf"); err == nil {
-		installType = ASDFRuby
-	}
-
-	return installType
-}
-
 func isSpecifiedRbenvRubyInstalled(message string) (bool, string, error) {
 	//
 	// Not installed
-	reg, err := regexp.Compile("rbenv: version \x60.*' is not installed") // \x60 == ` (The go linter suggested to use the hex code instead)
+	regexPattern := "rbenv: version \x60.*' is not installed" // \x60 == ` (The go linter suggested to use the hex code instead)
+	reg, err := regexp.Compile(regexPattern)
 	if err != nil {
-		return false, "", fmt.Errorf("failed to parse regex ( %s ) on the error message, error: %s", "rbenv: version \x60.*' is not installed", err) // \x60 == ` (The go linter suggested to use the hex code instead)
+		return false, "", fmt.Errorf("failed to parse regex ( %s ) on the error message, error: %s", regexPattern, err)
 	}
 
 	var version string
@@ -151,6 +152,46 @@ func isSpecifiedRbenvRubyInstalled(message string) (bool, string, error) {
 		return true, version, nil
 	}
 	return false, version, nil
+}
+
+func (m environment) IsSpecifiedASDFRubyInstalled(workdir string) (isInstalled bool, versionInstalled string, error error) {
+	absWorkdir, err := pathutil.AbsPath(workdir)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to get absolute path for ( %s ), error: %s", workdir, err)
+	}
+
+	cmd := m.factory.Create("asdf", []string{"current", "ruby"}, &command.Opts{Dir: absWorkdir})
+	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	if err != nil {
+		m.logger.Warnf("failed to check installed ruby version, %s error: %s", out, err)
+	}
+
+	return isSpecifiedASDFRubyInstalled(out)
+}
+
+func isSpecifiedASDFRubyInstalled(message string) (isInstalled bool, versionInstalled string, error error) {
+	regexPattern := "Not installed. Run \"asdf install ruby .*\""
+	reg, err := regexp.Compile(regexPattern)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to parse regex ( %s ) on the error message, error: %s", regexPattern, err)
+	}
+
+	var version string
+	if reg.MatchString(message) {
+		//
+		// Not installed
+		version = strings.Split(strings.Split(message, "\"asdf install ruby ")[1], "\"")[0]
+		return false, version, nil
+	}
+	//
+	// Installed
+	patternTerminator := "/"
+	if strings.Contains(message, "ASDF_RUBY_VERSION") {
+		patternTerminator = "ASDF_RUBY_VERSION"
+	}
+	version = strings.Split(strings.Split(message, "ruby ")[1], patternTerminator)[0]
+	version = strings.TrimSpace(version)
+	return true, version, nil
 }
 
 func findGemInList(gemList, gem, version string) (bool, error) {

--- a/ruby/environment.go
+++ b/ruby/environment.go
@@ -85,7 +85,7 @@ func rubyInstallType(cmdLocator env.CommandLocator) InstallType {
 	} else if _, err := cmdLocator.LookPath("asdf"); err == nil {
 		// asdf doesn't store its installs in a definite location,
 		// but it does store its shims in a 'shims' directory, which
-		// is what we get when we'll get from the `LookPath` call above.
+		// is what we'll get from the `LookPath("ruby")` call above.
 		if strings.Contains(pth, "shims/ruby") {
 			installType = ASDFRuby
 		}

--- a/ruby/environment_test.go
+++ b/ruby/environment_test.go
@@ -300,10 +300,10 @@ func Test_RubyInstallTypeRbenv(t *testing.T) {
 
 func Test_RubyInstallTypeASDF(t *testing.T) {
 	mockCommandLocator := new(mocks.CommandLocator)
-	mockCommandLocator.On("LookPath", "ruby").Return("", nil)
+	mockCommandLocator.On("LookPath", "ruby").Return("/path/to/.asdf/shims/ruby", nil)
 	mockCommandLocator.On("LookPath", "rbenv").Return("", fmt.Errorf("exit status 1"))
 	mockCommandLocator.On("LookPath", "rvm").Return("", fmt.Errorf("exit status 1"))
-	mockCommandLocator.On("LookPath", "asdf").Return("/some/path/to/.asdf", nil)
+	mockCommandLocator.On("LookPath", "asdf").Return("/opt/homebrew/opt/asdf/libexec/bin/asdf", nil)
 
 	m := NewEnvironment(new(mocks.CommandFactory), mockCommandLocator, log.NewLogger())
 	installType := m.RubyInstallType()

--- a/ruby/mocks/CommandLocator.go
+++ b/ruby/mocks/CommandLocator.go
@@ -1,0 +1,27 @@
+package mocks
+
+import "github.com/stretchr/testify/mock"
+
+type CommandLocator struct {
+	mock.Mock
+}
+
+func (_m *CommandLocator) LookPath(file string) (string, error) {
+	ret := _m.Called(file)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(file)
+	} else {
+		r0, _ = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(file)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}


### PR DESCRIPTION
This update adds support for Ruby versions installed using the [asdf version manager](https://asdf-vm.com). asdf is not currently used in CI, but it is a popular tool for developers to use on their machines — and selfishly, it's what I use on my machine. :)

This change builds off of work by @matrangam in https://github.com/bitrise-io/go-steputils/pull/46, but goes a couple steps further by adding asdf reshimming when gems are installed, and a more accurate check for if ruby is installed via asdf.

## Changes

- Adds `ASDFRuby` type ([here](https://github.com/bitrise-io/go-steputils/pull/53/files#diff-2e55ae2cb609a670cb5e604220dc4cc807e12280874deb8146570bf4b30fef19R36-R37)) and a check for it in `rubyInstallType` ([here](https://github.com/bitrise-io/go-steputils/pull/53/files#diff-2e55ae2cb609a670cb5e604220dc4cc807e12280874deb8146570bf4b30fef19R85-R92)).
- Adds methods for checking if the specified asdf-installed Ruby version is installed ([here](https://github.com/bitrise-io/go-steputils/pull/53/files#diff-2e55ae2cb609a670cb5e604220dc4cc807e12280874deb8146570bf4b30fef19R162-R201)).
- Adds `asdf reshim ruby` command after installs/updates of gems ([here](https://github.com/bitrise-io/go-steputils/pull/53/files#diff-96a0a74e61aea0772f5ce733402e4ad6862a08a1e5330698ec2ab103afbe5dbdR67-R69) & [here](https://github.com/bitrise-io/go-steputils/pull/53/files#diff-96a0a74e61aea0772f5ce733402e4ad6862a08a1e5330698ec2ab103afbe5dbdR83-R85)).
- Adds tests for the new code.