### PR TITLE
Skip directories in hashing

### DIFF
--- a/cache/keytemplate/checksum.go
+++ b/cache/keytemplate/checksum.go
@@ -21,8 +21,7 @@ func (m Model) checksum(paths ...string) string {
 		return ""
 	}
 
-	evaluatedPaths := m.evaluateGlobPatterns(workingDir, paths)
-	files := filterFilesOnly(evaluatedPaths)
+	files := m.evaluateGlobPatterns(workingDir, paths)
 	m.logger.Debugf("Files included in checksum:")
 	for _, path := range files {
 		m.logger.Debugf("- %s", path)
@@ -75,7 +74,7 @@ func (m Model) evaluateGlobPatterns(workingDir string, paths []string) []string 
 		}
 	}
 
-	return finalPaths
+	return filterFilesOnly(finalPaths)
 }
 
 func checksumOfFile(path string) ([]byte, error) {
@@ -100,5 +99,6 @@ func filterFilesOnly(paths []string) []string {
 		}
 		files = append(files, path)
 	}
+
 	return files
 }

--- a/cache/keytemplate/checksum.go
+++ b/cache/keytemplate/checksum.go
@@ -20,7 +20,9 @@ func (m Model) checksum(paths ...string) string {
 		m.logger.Errorf(err.Error())
 		return ""
 	}
-	files := m.evaluateGlobPatterns(workingDir, paths)
+
+	evaluatedPaths := m.evaluateGlobPatterns(workingDir, paths)
+	files := filterFilesOnly(evaluatedPaths)
 	m.logger.Debugf("Files included in checksum:")
 	for _, path := range files {
 		m.logger.Debugf("- %s", path)
@@ -84,4 +86,19 @@ func checksumOfFile(path string) ([]byte, error) {
 	}
 	hash.Write(b)
 	return hash.Sum(nil), nil
+}
+
+func filterFilesOnly(paths []string) []string {
+	var files []string
+	for _, path := range paths {
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		if info.IsDir() {
+			continue
+		}
+		files = append(files, path)
+	}
+	return files
 }


### PR DESCRIPTION
### Context

The cache key checksum function tries to hash every parameter passed to it, even if it’s not a file. Right now it results in the following warning:

```
Error while hashing .gradle: read .gradle: is a directory
```

This happens when the cache key uses glob patterns that are meant to match files but also match a similarly named folder: `gradle-cache-{{ checksum "**/*.gradle" "/gradle-wrapper.properties" }}`

### Changes

After evaluating the glob patterns, filter out the directories from the matched paths.

Note: there is already a test case that covers this scenario, so I only added the appropriate test folder structure to trigger the scenario.
