### PR TITLE
Log cache template warning as debug

### DIFF
--- a/cache/keytemplate/keytemplate.go
+++ b/cache/keytemplate/keytemplate.go
@@ -87,6 +87,6 @@ func (m Model) validateInventory(inventory templateInventory) {
 
 func (m Model) warnIfEmpty(name, value string) {
 	if value == "" {
-		m.logger.Warnf("Template variable .%s is not defined", name)
+		m.logger.Debugf("Template variable .%s is not defined", name)
 	}
 }


### PR DESCRIPTION
This warning is not really actionable for the user, so it feels strange to see this warning in the logs.

Also, the `.CommitHash` variable is one that is often not defined, for example in manually triggered builds.