### PR TITLE
Fix pattern matching in absolute paths

### DIFF
--- a/cache/keytemplate/checksum.go
+++ b/cache/keytemplate/checksum.go
@@ -4,9 +4,11 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
+	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bmatcuk/doublestar/v4"
 )
 
@@ -15,13 +17,7 @@ import (
 // The path list is sorted alphabetically to produce consistent output.
 // Errors are logged as warnings and an empty string is returned in that case.
 func (m Model) checksum(paths ...string) string {
-	workingDir, err := os.Getwd()
-	if err != nil {
-		m.logger.Errorf(err.Error())
-		return ""
-	}
-
-	files := m.evaluateGlobPatterns(workingDir, paths)
+	files := m.evaluateGlobPatterns(paths)
 	m.logger.Debugf("Files included in checksum:")
 	for _, path := range files {
 		m.logger.Debugf("- %s", path)
@@ -54,12 +50,18 @@ func (m Model) checksum(paths ...string) string {
 	return hex.EncodeToString(finalChecksum.Sum(nil))
 }
 
-func (m Model) evaluateGlobPatterns(workingDir string, paths []string) []string {
+func (m Model) evaluateGlobPatterns(paths []string) []string {
 	var finalPaths []string
 
 	for _, path := range paths {
 		if strings.Contains(path, "*") {
-			matches, err := doublestar.Glob(os.DirFS(workingDir), path)
+			base, pattern := doublestar.SplitPattern(path)
+			absBase, err := pathutil.NewPathModifier().AbsPath(base)
+			if err != nil {
+				m.logger.Warnf("Failed to convert %s to an absolute path: %s", path, err)
+				continue
+			}
+			matches, err := doublestar.Glob(os.DirFS(absBase), pattern)
 			if matches == nil {
 				m.logger.Warnf("No match for pattern: %s", path)
 				continue
@@ -68,7 +70,9 @@ func (m Model) evaluateGlobPatterns(workingDir string, paths []string) []string 
 				m.logger.Warnf("Error in pattern '%s': %s", path, err)
 				continue
 			}
-			finalPaths = append(finalPaths, matches...)
+			for _, match := range matches {
+				finalPaths = append(finalPaths, filepath.Join(base, match))
+			}
 		} else {
 			finalPaths = append(finalPaths, path)
 		}

--- a/cache/keytemplate/checksum_test.go
+++ b/cache/keytemplate/checksum_test.go
@@ -1,6 +1,7 @@
 package keytemplate
 
 import (
+	"path/filepath"
 	"runtime"
 	"testing"
 
@@ -8,6 +9,11 @@ import (
 )
 
 func TestChecksum(t *testing.T) {
+	testdataAbsPath, err := filepath.Abs("testdata")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
 	tests := []struct {
 		name  string
 		paths []string
@@ -52,6 +58,11 @@ func TestChecksum(t *testing.T) {
 			name:  "Multiple glob stars",
 			paths: []string{"testdata/**/*.gradle*"},
 			want:  "563cf037f336453ee1888c3dcbe1c687ebeb6c593d4d0bd57ccc5fc49daa3951",
+		},
+		{
+			name:  "Absolute path and glob star",
+			paths: []string{filepath.Join(testdataAbsPath, "*.gradle")},
+			want:  "db094ffe3aea59fc48766cb408894ada1c67dbd355d25085729394df82fb1eda",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### Context

Pattern matching in the `checksum` template function is not working when the path is an absolute path (or one that gets expanded to an absolute path), such as:

```
~/Library/Developer/Xcode/DerivedData/**/SourcePackages
```

### Changes

Fix glob pattern matching by splitting the path input into a base path and a pattern. Relevant section from the docs of `doublestar.Glob()`:

> // Like `io/fs.Glob()`, patterns containing `/./`, `/../`, or starting with `/`
> // will return no results and no errors. You can use SplitPattern to divide a
> // pattern into a base path (to initialize an `FS` object) and pattern.