### PR TITLE
Use standard linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   skip-dirs:
-  - ".*/mocks"
+  - .*/mocks
 
 issues:
   # https://github.com/golangci/golangci-lint/issues/2439
@@ -24,4 +24,3 @@ linters-settings:
     - name: exported
       arguments:
       - checkPrivateReceivers
-

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,27 @@
+run:
+  skip-dirs:
+  - ".*/mocks"
+
+issues:
+  # https://github.com/golangci/golangci-lint/issues/2439
+  exclude-use-default: false
+
+linters:
+  enable:
+  - errcheck
+  - gosimple
+  - govet
+  - ineffassign
+  - staticcheck
+  - typecheck
+  - unused
+  - revive
+
+linters-settings:
+  revive:
+    severity: error
+    rules:
+    - name: exported
+      arguments:
+      - checkPrivateReceivers
+

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -8,10 +8,13 @@ workflows:
 
   test:
     steps:
+    - git::https://github.com/bitrise-steplib/steps-check.git:
+        title: Lint
+        inputs:
+        - workflow: lint
+        - skip_step_yml_validation: "yes"
     - go-list:
         inputs:
         - exclude: |-
             */mocks
-    - golint: { }
-    - errcheck: { }
     - go-test: { }

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.1
 	github.com/bmatcuk/doublestar/v4 v4.2.0
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/text v0.3.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -1,9 +1,7 @@
 package output
 
 import (
-	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"testing"
 
@@ -107,19 +105,4 @@ func TestZipMixedFilesAndFoldersAndExportOutput(t *testing.T) {
 	destinationZip := filepath.Join(tmpDir, "destination.zip")
 
 	require.Error(t, ZipAndExportOutput(sourceFilePaths, destinationZip, "EXPORTED_ZIP_PATH"))
-}
-
-func givenTmpLogFilePath(t *testing.T) string {
-	tmp, err := ioutil.TempDir("", "log")
-	require.NoError(t, err)
-
-	return path.Join(tmp, "log.txt")
-}
-
-func requireFileContents(t *testing.T, contents, filePath string) {
-	byteContents, err := ioutil.ReadFile(filePath)
-	require.NoError(t, err)
-
-	stringContents := string(byteContents)
-	require.Equal(t, contents, stringContents)
 }

--- a/ruby/command.go
+++ b/ruby/command.go
@@ -35,6 +35,7 @@ func NewCommandFactory(cmdFactory command.Factory, cmdLocator env.CommandLocator
 	}, nil
 }
 
+// Create ...
 func (f commandFactory) Create(name string, args []string, opts *command.Opts) command.Command {
 	s := append([]string{name}, args...)
 	if sudoNeeded(f.installType, s...) {

--- a/ruby/environment.go
+++ b/ruby/environment.go
@@ -94,6 +94,7 @@ func rubyInstallType(cmdLocator env.CommandLocator) InstallType {
 	return installType
 }
 
+// IsGemInstalled returns true if the specified gem version is installed
 func (m environment) IsGemInstalled(gem, version string) (bool, error) {
 	cmd := m.factory.Create("gem", []string{"list"}, nil)
 
@@ -159,6 +160,7 @@ func isSpecifiedRbenvRubyInstalled(message string) (bool, string, error) {
 	return false, version, nil
 }
 
+// IsSpecifiedASDFRubyInstalled ...
 func (m environment) IsSpecifiedASDFRubyInstalled(workdir string) (isInstalled bool, versionInstalled string, error error) {
 	absWorkdir, err := pathutil.AbsPath(workdir)
 	if err != nil {

--- a/ruby/environment.go
+++ b/ruby/environment.go
@@ -146,7 +146,7 @@ func isSpecifiedRbenvRubyInstalled(message string) (bool, string, error) {
 
 	//
 	// Installed
-	reg, err = regexp.Compile(".* \\(set by")
+	reg, err = regexp.Compile(`.* \(set by`)
 	if err != nil {
 		return false, "", fmt.Errorf("failed to parse regex ( %s ) on the error message, error: %s", ".* \\(set by", err)
 	}

--- a/stepconf/strings.go
+++ b/stepconf/strings.go
@@ -3,13 +3,14 @@ package stepconf
 import (
 	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/bitrise-io/go-utils/colorstring"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // Print the name of the struct with Title case in blue color with followed by a newline,
-// then print all fields formatted as '- field name: field value` separated by newline.
+// then print all fields formatted as `- field name: field value` separated by newline.
 func Print(config interface{}) {
 	fmt.Print(toString(config))
 }
@@ -17,7 +18,7 @@ func Print(config interface{}) {
 func valueString(v reflect.Value) string {
 	if v.Kind() != reflect.Ptr {
 		if v.Kind() == reflect.String && v.Len() == 0 {
-			return fmt.Sprintf("<unset>")
+			return "<unset>"
 		}
 		return fmt.Sprintf("%v", v.Interface())
 	}
@@ -30,7 +31,7 @@ func valueString(v reflect.Value) string {
 }
 
 // returns the name of the struct with Title case in blue color followed by a newline,
-// then print all fields formatted as '- field name: field value` separated by newline.
+// then print all fields formatted as `- field name: field value` separated by newline.
 func toString(config interface{}) string {
 	v := reflect.ValueOf(config)
 	t := reflect.TypeOf(config)
@@ -43,7 +44,8 @@ func toString(config interface{}) string {
 		t = t.Elem()
 	}
 
-	str := fmt.Sprint(colorstring.Bluef("%s:\n", strings.Title(t.Name())))
+	titleCaseName := cases.Title(language.English, cases.NoLower).String(t.Name())
+	str := fmt.Sprint(colorstring.Bluef("%s:\n", titleCaseName))
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 		var key, _ = parseTag(field.Tag.Get("env"))


### PR DESCRIPTION
Use the standard linters and config we use in other step repos.

This PR drops `errcheck` and `golint` in favor of `golangci-lint` through the `check` internal step.

There were a few lint violations with the new rules, this PR fixes those.

```
output/output_test.go:112:6: `givenTmpLogFilePath` is unused (deadcode)
func givenTmpLogFilePath(t *testing.T) string {
     ^
output/output_test.go:119:6: `requireFileContents` is unused (deadcode)
func requireFileContents(t *testing.T, contents, filePath string) {
     ^
stepconf/strings.go:20:11: S1039: unnecessary use of fmt.Sprintf (gosimple)
			return fmt.Sprintf("<unset>")
			       ^
ruby/environment.go:149:13: S1007: should use raw string (`...`) with regexp.Compile to avoid having to escape twice (gosimple)
	reg, err = regexp.Compile(".* \\(set by")
	           ^
stepconf/strings.go:46:47: SA1019: strings.Title has been deprecated since Go 1.18 and an alternative has been available since Go 1.0: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead. (staticcheck)
	str := fmt.Sprint(colorstring.Bluef("%s:\n", strings.Title(t.Name())))
```