### PR TITLE
Create `cache.Restorer`

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -51,7 +51,7 @@ workflows:
                 --data "client_id=abcs-steps" \
                 --data "client_secret=$CACHE_API_CLIENT_SECRET" \
                 --data "grant_type=urn:ietf:params:oauth:grant-type:uma-ticket" \
-                --data "claim_token=eyJhcHBfaWQiOlsic3RlcC1zYXZlLWNhY2hlLWUyZS10ZXN0cyJdLCAiaXNfY3JlZGl0X2Jhc2VkIjpbInRydWUiXSwgImlzX3ByaXZhdGVfY2xvdWQiOlsidHJ1ZSJdfQ==" \
+                --data "claim_token=eyJhcHBfaWQiOlsic3RlcC1zYXZlLWNhY2hlLWUyZS10ZXN0cyJdLCAiYWNjZXNzX2dyYW50ZWQiOlsidHJ1ZSJdfQ==" \
                 --data "claim_token_format=urn:ietf:params:oauth:token-type:jwt" \
                 --data "audience=advanced-build-cache-service")
 

--- a/cache/restore.go
+++ b/cache/restore.go
@@ -1,0 +1,164 @@
+package cache
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/bitrise-io/go-steputils/v2/cache/compression"
+	"github.com/bitrise-io/go-steputils/v2/cache/keytemplate"
+	"github.com/bitrise-io/go-steputils/v2/cache/network"
+	"github.com/bitrise-io/go-steputils/v2/stepconf"
+	"github.com/bitrise-io/go-utils/v2/env"
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/docker/go-units"
+)
+
+// RestoreCacheInput is the information that comes from the cache steps that call this shared implementation
+type RestoreCacheInput struct {
+	// StepId identifies the exact cache step. Used for logging events.
+	StepId  string
+	Verbose bool
+	Keys    []string
+}
+
+// Restorer ...
+type Restorer interface {
+	Restore(input RestoreCacheInput) error
+}
+
+type restoreCacheConfig struct {
+	Verbose        bool
+	Keys           []string
+	APIBaseURL     stepconf.Secret
+	APIAccessToken stepconf.Secret
+}
+
+type restorer struct {
+	envRepo env.Repository
+	logger  log.Logger
+}
+
+// NewRestorer ...
+func NewRestorer(envRepo env.Repository, logger log.Logger) *restorer {
+	return &restorer{envRepo: envRepo, logger: logger}
+}
+
+// Restore ...
+func (r *restorer) Restore(input RestoreCacheInput) error {
+	config, err := r.createConfig(input)
+	if err != nil {
+		return fmt.Errorf("failed to parse inputs: %w", err)
+	}
+
+	tracker := newStepTracker(input.StepId, r.envRepo, r.logger)
+
+	r.logger.Println()
+	r.logger.Infof("Downloading archive...")
+	downloadStartTime := time.Now()
+	archivePath, err := r.download(config)
+	if err != nil {
+		return fmt.Errorf("download failed: %w", err)
+	}
+	fileInfo, err := os.Stat(archivePath)
+	if err != nil {
+		return err
+	}
+	r.logger.Printf("Archive size: %s", units.HumanSizeWithPrecision(float64(fileInfo.Size()), 3))
+	downloadTime := time.Since(downloadStartTime).Round(time.Second)
+	r.logger.Donef("Downloaded archive in %s", downloadTime)
+	tracker.logArchiveDownloaded(downloadTime, fileInfo, len(config.Keys))
+
+	r.logger.Println()
+	r.logger.Infof("Restoring archive...")
+	extractionStartTime := time.Now()
+	if err := compression.Decompress(archivePath, r.logger, r.envRepo); err != nil {
+		return fmt.Errorf("failed to decompress cache archive: %w", err)
+	}
+	extractionTime := time.Since(extractionStartTime).Round(time.Second)
+	r.logger.Donef("Restored archive in %s", extractionTime)
+	tracker.logArchiveExtracted(extractionTime, len(config.Keys))
+	tracker.wait()
+
+	return nil
+}
+
+func (r *restorer) createConfig(input RestoreCacheInput) (restoreCacheConfig, error) {
+	apiBaseURL := r.envRepo.Get("BITRISEIO_ABCS_API_URL")
+	if apiBaseURL == "" {
+		return restoreCacheConfig{}, fmt.Errorf("the secret 'BITRISEIO_ABCS_API_URL' is not defined")
+	}
+	apiAccessToken := r.envRepo.Get("BITRISEIO_ABCS_ACCESS_TOKEN")
+	if apiAccessToken == "" {
+		return restoreCacheConfig{}, fmt.Errorf("the secret 'BITRISEIO_ABCS_ACCESS_TOKEN' is not defined")
+	}
+
+	keys, err := r.evaluateKeys(input.Keys)
+	if err != nil {
+		return restoreCacheConfig{}, fmt.Errorf("failed to evaluate keys: %w", err)
+	}
+
+	return restoreCacheConfig{
+		Verbose:        input.Verbose,
+		Keys:           keys,
+		APIBaseURL:     stepconf.Secret(apiBaseURL),
+		APIAccessToken: stepconf.Secret(apiAccessToken),
+	}, nil
+}
+
+func (r *restorer) evaluateKeys(keys []string) ([]string, error) {
+	model := keytemplate.NewModel(r.envRepo, r.logger)
+	buildContext := keytemplate.BuildContext{
+		Workflow:   r.envRepo.Get("BITRISE_TRIGGERED_WORKFLOW_ID"),
+		Branch:     r.envRepo.Get("BITRISE_GIT_BRANCH"),
+		CommitHash: r.envRepo.Get("BITRISE_GIT_COMMIT"),
+	}
+
+	var evaluatedKeys []string
+	for _, key := range keys {
+		if key == "" {
+			continue
+		}
+
+		r.logger.Println()
+		r.logger.Printf("Evaluating key template: %s", key)
+		evaluatedKey, err := model.Evaluate(key, buildContext)
+		if err != nil {
+			return nil, fmt.Errorf("failed to evaluate key template: %s", err)
+		}
+		r.logger.Donef("Cache key: %s", evaluatedKey)
+		evaluatedKeys = append(evaluatedKeys, evaluatedKey)
+	}
+
+	return evaluatedKeys, nil
+}
+
+func (r *restorer) download(config restoreCacheConfig) (string, error) {
+	dir, err := os.MkdirTemp("", "restore-cache")
+	if err != nil {
+		return "", err
+	}
+	name := fmt.Sprintf("cache-%s.tzst", time.Now().UTC().Format("20060102-150405"))
+	downloadPath := filepath.Join(dir, name)
+
+	params := network.DownloadParams{
+		APIBaseURL:   string(config.APIBaseURL),
+		Token:        string(config.APIAccessToken),
+		CacheKeys:    config.Keys,
+		DownloadPath: downloadPath,
+	}
+	err = network.Download(params, r.logger)
+	if err != nil {
+		if errors.Is(err, network.ErrCacheNotFound) {
+			r.logger.Donef("No cache entry found for the provided key")
+			os.Exit(0)
+		}
+		return "", err
+	}
+
+	r.logger.Debugf("Archive downloaded to %s", downloadPath)
+
+	return downloadPath, nil
+}

--- a/cache/restore.go
+++ b/cache/restore.go
@@ -60,6 +60,10 @@ func (r *restorer) Restore(input RestoreCacheInput) error {
 	downloadStartTime := time.Now()
 	archivePath, err := r.download(config)
 	if err != nil {
+		if errors.Is(err, network.ErrCacheNotFound) {
+			r.logger.Donef("No cache entry found for the provided key")
+			return nil
+		}
 		return fmt.Errorf("download failed: %w", err)
 	}
 	fileInfo, err := os.Stat(archivePath)
@@ -151,10 +155,6 @@ func (r *restorer) download(config restoreCacheConfig) (string, error) {
 	}
 	err = network.Download(params, r.logger)
 	if err != nil {
-		if errors.Is(err, network.ErrCacheNotFound) {
-			r.logger.Donef("No cache entry found for the provided key")
-			os.Exit(0)
-		}
 		return "", err
 	}
 

--- a/cache/restore_test.go
+++ b/cache/restore_test.go
@@ -1,0 +1,155 @@
+package cache
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+)
+
+func Test_ProcessRestoreConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   RestoreCacheInput
+		want    restoreCacheConfig
+		wantErr bool
+	}{
+		{
+			name: "Valid key input",
+			input: RestoreCacheInput{
+				Verbose: true,
+				Keys:    []string{"valid-key"},
+			},
+			want: restoreCacheConfig{
+				Verbose:        true,
+				Keys:           []string{"valid-key"},
+				APIBaseURL:     "fake service URL",
+				APIAccessToken: "fake access token",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid key input with multiple keys",
+			input: RestoreCacheInput{
+				Verbose: true,
+				Keys: []string{
+					"valid-key",
+					"valid-key-2",
+				},
+			},
+			want: restoreCacheConfig{
+				Verbose:        true,
+				Keys:           []string{"valid-key", "valid-key-2"},
+				APIBaseURL:     "fake service URL",
+				APIAccessToken: "fake access token",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Given
+			step := restorer{
+				logger: log.NewLogger(),
+				envRepo: fakeEnvRepo{envVars: map[string]string{
+					"BITRISEIO_ABCS_API_URL":      "fake service URL",
+					"BITRISEIO_ABCS_ACCESS_TOKEN": "fake access token",
+				}},
+			}
+
+			// When
+			processedConfig, err := step.createConfig(testCase.input)
+
+			// Then
+			if (err != nil) != testCase.wantErr {
+				t.Errorf("ProcessConfig() error = %v, wantErr %v", err, testCase.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(processedConfig, testCase.want) {
+				t.Errorf("ProcessConfig() = %v, want %v", processedConfig, testCase.want)
+			}
+		})
+	}
+}
+
+func Test_evaluateKeys(t *testing.T) {
+	type args struct {
+		keys    []string
+		envRepo fakeEnvRepo
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "Happy path",
+			args: args{
+				keys: []string{"npm-cache-{{ .Branch }}"},
+				envRepo: fakeEnvRepo{
+					envVars: map[string]string{
+						"BITRISE_WORKFLOW_ID": "primary",
+						"BITRISE_GIT_BRANCH":  "main",
+						"BITRISE_GIT_COMMIT":  "9de033412f24b70b59ca8392ccb9f61ac5af4cc3",
+					},
+				},
+			},
+			want:    []string{"npm-cache-main"},
+			wantErr: false,
+		},
+		{
+			name: "Multiple keys",
+			args: args{
+				keys: []string{
+					"npm-cache-{{ .Branch }}",
+					"npm-cache-",
+					"",
+				},
+				envRepo: fakeEnvRepo{
+					envVars: map[string]string{
+						"BITRISE_WORKFLOW_ID": "primary",
+						"BITRISE_GIT_BRANCH":  "main",
+						"BITRISE_GIT_COMMIT":  "9de033412f24b70b59ca8392ccb9f61ac5af4cc3",
+					},
+				},
+			},
+			want: []string{
+				"npm-cache-main",
+				"npm-cache-",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Empty environment variables",
+			args: args{
+				keys:    []string{"npm-cache-{{ .Branch }}"},
+				envRepo: fakeEnvRepo{},
+			},
+			want:    []string{"npm-cache-"},
+			wantErr: false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Given
+			step := restorer{
+				logger:  log.NewLogger(),
+				envRepo: testCase.args.envRepo,
+			}
+
+			// When
+			evaluatedKeys, err := step.evaluateKeys(testCase.args.keys)
+			if (err != nil) != testCase.wantErr {
+				t.Errorf("evaluateKey() error = %v, wantErr %v", err, testCase.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(evaluatedKeys, testCase.want) {
+				t.Errorf("evaluateKey() = %v, want %v", evaluatedKeys, testCase.want)
+			}
+		})
+	}
+}

--- a/cache/save_test.go
+++ b/cache/save_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/pathutil"
 )
 
-func Test_ProcessConfig(t *testing.T) {
+func Test_ProcessSaveConfig(t *testing.T) {
 	testdataAbsPath, err := filepath.Abs("testdata")
 	if err != nil {
 		t.Fatalf(err.Error())

--- a/cache/tracker.go
+++ b/cache/tracker.go
@@ -45,6 +45,23 @@ func (t *stepTracker) logArchiveCompressed(compressionTime time.Duration, pathCo
 	t.tracker.Enqueue("step_save_cache_archive_compressed", properties)
 }
 
+func (t *stepTracker) logArchiveDownloaded(downloadTime time.Duration, info fs.FileInfo, keyCount int) {
+	properties := analytics.Properties{
+		"download_time_s":     downloadTime.Truncate(time.Second).Seconds(),
+		"download_size_bytes": info.Size(),
+		"key_count":           keyCount,
+	}
+	t.tracker.Enqueue("step_restore_cache_archive_downloaded", properties)
+}
+
+func (t *stepTracker) logArchiveExtracted(extractionTime time.Duration, keyCount int) {
+	properties := analytics.Properties{
+		"extraction_time_s": extractionTime.Truncate(time.Second).Seconds(),
+		"key_count":         keyCount,
+	}
+	t.tracker.Enqueue("step_restore_cache_archive_extracted", properties)
+}
+
 func (t *stepTracker) wait() {
 	t.tracker.Wait()
 }


### PR DESCRIPTION
### Context

Sharing the cache implementation across steps by moving it into this shared library. Follow-up to #60 and #62 and #63

### Changes

- Create `cache.Restorer`, which will be the main entry point for the various cache steps
- Move over analytics logging methods to `tracker.go` from step code
- `restore.go` contains all the code that glues together network calls, compression, analytics, logging, etc.