### PR TITLE
Small fixes

### DIFF
--- a/cache/network/upload.go
+++ b/cache/network/upload.go
@@ -20,7 +20,7 @@ type UploadParams struct {
 
 // Upload a cache archive and associate it with the provided cache key
 func Upload(params UploadParams, logger log.Logger) error {
-	validatedKey, err := validateKey(params.CacheKey)
+	validatedKey, err := validateKey(params.CacheKey, logger)
 	if err != nil {
 		return err
 	}
@@ -58,12 +58,13 @@ func Upload(params UploadParams, logger log.Logger) error {
 	return nil
 }
 
-func validateKey(key string) (string, error) {
+func validateKey(key string, logger log.Logger) (string, error) {
 	if strings.Contains(key, ",") {
 		return "", fmt.Errorf("commas are not allowed in key")
 	}
 
 	if len(key) > maxKeyLength {
+		logger.Warnf("Key is too long, truncating it to the first %d characters", maxKeyLength)
 		return key[:maxKeyLength], nil
 	}
 	return key, nil

--- a/cache/network/upload_test.go
+++ b/cache/network/upload_test.go
@@ -3,6 +3,8 @@ package network
 import (
 	"strings"
 	"testing"
+
+	"github.com/bitrise-io/go-utils/v2/log"
 )
 
 func Test_validateKey(t *testing.T) {
@@ -30,7 +32,7 @@ func Test_validateKey(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := validateKey(tt.key)
+			got, err := validateKey(tt.key, log.NewLogger())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("validateKey() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/cache/save.go
+++ b/cache/save.go
@@ -136,7 +136,7 @@ func (s *saver) createConfig(input SaveCacheInput) (saveCacheConfig, error) {
 
 	return saveCacheConfig{
 		Verbose:        input.Verbose,
-		Key:            input.Key,
+		Key:            evaluatedKey,
 		Paths:          finalPaths,
 		APIBaseURL:     stepconf.Secret(apiBaseURL),
 		APIAccessToken: stepconf.Secret(apiAccessToken),

--- a/cache/save_test.go
+++ b/cache/save_test.go
@@ -37,6 +37,22 @@ func Test_ProcessSaveConfig(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "Key with template",
+			input: SaveCacheInput{
+				Verbose: false,
+				Key:     `test-key-{{ getenv "INTEGRATION_TEST_ENV" }}`,
+				Paths:   []string{"/dev/null"},
+			},
+			want: saveCacheConfig{
+				Verbose:        false,
+				Key:            "test-key-test_value",
+				Paths:          []string{"/dev/null"},
+				APIBaseURL:     "fake cache service URL",
+				APIAccessToken: "fake cache service access token",
+			},
+			wantErr: false,
+		},
+		{
 			name: "Single file path",
 			input: SaveCacheInput{
 				Verbose: false,
@@ -101,6 +117,7 @@ func Test_ProcessSaveConfig(t *testing.T) {
 				envRepo: fakeEnvRepo{envVars: map[string]string{
 					"BITRISEIO_ABCS_API_URL":      "fake cache service URL",
 					"BITRISEIO_ABCS_ACCESS_TOKEN": "fake cache service access token",
+					"INTEGRATION_TEST_ENV":        "test_value",
 				}},
 			}
 			got, err := step.createConfig(tt.input)


### PR DESCRIPTION
- Add a warning when the cache key is too long and gets truncated
- Fix using the evaluated cache key instead of the raw template