### PR TITLE
Use fallback commit hash value

### DIFF
--- a/cache/restore.go
+++ b/cache/restore.go
@@ -114,11 +114,6 @@ func (r *restorer) createConfig(input RestoreCacheInput) (restoreCacheConfig, er
 
 func (r *restorer) evaluateKeys(keys []string) ([]string, error) {
 	model := keytemplate.NewModel(r.envRepo, r.logger)
-	buildContext := keytemplate.BuildContext{
-		Workflow:   r.envRepo.Get("BITRISE_TRIGGERED_WORKFLOW_ID"),
-		Branch:     r.envRepo.Get("BITRISE_GIT_BRANCH"),
-		CommitHash: r.envRepo.Get("BITRISE_GIT_COMMIT"),
-	}
 
 	var evaluatedKeys []string
 	for _, key := range keys {
@@ -128,7 +123,7 @@ func (r *restorer) evaluateKeys(keys []string) ([]string, error) {
 
 		r.logger.Println()
 		r.logger.Printf("Evaluating key template: %s", key)
-		evaluatedKey, err := model.Evaluate(key, buildContext)
+		evaluatedKey, err := model.Evaluate(key)
 		if err != nil {
 			return nil, fmt.Errorf("failed to evaluate key template: %s", err)
 		}

--- a/cache/save.go
+++ b/cache/save.go
@@ -198,13 +198,7 @@ func (s *saver) evaluatePaths(paths []string) ([]string, error) {
 
 func (s *saver) evaluateKey(keyTemplate string) (string, error) {
 	model := keytemplate.NewModel(s.envRepo, s.logger)
-	buildContext := keytemplate.BuildContext{
-		Workflow:   s.envRepo.Get("BITRISE_TRIGGERED_WORKFLOW_ID"),
-		Branch:     s.envRepo.Get("BITRISE_GIT_BRANCH"),
-		CommitHash: s.envRepo.Get("BITRISE_GIT_COMMIT"),
-	}
-
-	return model.Evaluate(keyTemplate, buildContext)
+	return model.Evaluate(keyTemplate)
 }
 
 func (s *saver) compress(paths []string) (string, error) {


### PR DESCRIPTION
### Context

The `.CommitHash` template variable is bound to the `BITRISE_GIT_COMMIT` env var, which is bound to the build trigger's commit hash value. This input is optional, usually manually triggered builds don't specify a commit hash.

In these cases, we can use a fallback value: the git clone step's output value for the actual commit hash (after checking out the specified branch).

### Changes

- Use the second env var's value as fallback and print a log statement
- Remove `BuildContext` struct and move env var parsing from the consumers to the `Evaluate()` method