### PR TITLE
Skip saving the cache if possible

### DIFF
--- a/cache/common.go
+++ b/cache/common.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"io"
 	"os"
 )
 
@@ -11,10 +12,17 @@ const cacheHitEnvVarPrefix = "BITRISE_CACHE_HIT__"
 
 func checksumOfFile(path string) (string, error) {
 	hash := sha256.New()
-	b, err := os.ReadFile(path)
+
+	file, err := os.Open(path)
 	if err != nil {
 		return "", err
 	}
-	hash.Write(b)
+	defer file.Close() //nolint:errcheck
+
+	_, err = io.Copy(hash, file)
+	if err != nil {
+		return "", err
+	}
+
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }

--- a/cache/common.go
+++ b/cache/common.go
@@ -1,0 +1,19 @@
+package cache
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+)
+
+const cacheHitEnvVarPrefix = "BITRISE_CACHE_HIT__"
+
+func checksumOfFile(path string) (string, error) {
+	hash := sha256.New()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	hash.Write(b)
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}

--- a/cache/common.go
+++ b/cache/common.go
@@ -6,6 +6,7 @@ import (
 	"os"
 )
 
+// We need this prefix because there could be multiple restore steps in one workflow with multiple cache keys
 const cacheHitEnvVarPrefix = "BITRISE_CACHE_HIT__"
 
 func checksumOfFile(path string) (string, error) {

--- a/cache/keytemplate/checksum.go
+++ b/cache/keytemplate/checksum.go
@@ -3,6 +3,7 @@ package keytemplate
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -83,11 +84,17 @@ func (m Model) evaluateGlobPatterns(paths []string) []string {
 
 func checksumOfFile(path string) ([]byte, error) {
 	hash := sha256.New()
-	b, err := os.ReadFile(path)
+	file, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
-	hash.Write(b)
+	defer file.Close() //nolint:errcheck
+
+	_, err = io.Copy(hash, file)
+	if err != nil {
+		return nil, err
+	}
+
 	return hash.Sum(nil), nil
 }
 

--- a/cache/network/download.go
+++ b/cache/network/download.go
@@ -23,31 +23,31 @@ var ErrCacheNotFound = errors.New("no cache archive found for the provided keys"
 
 // Download archive from the cache API based on the provided keys in params.
 // If there is no match for any of the keys, the error is ErrCacheNotFound.
-func Download(params DownloadParams, logger log.Logger) error {
+func Download(params DownloadParams, logger log.Logger) (matchedKey string, err error) {
 	if params.APIBaseURL == "" {
-		return fmt.Errorf("API base URL is empty")
+		return "", fmt.Errorf("API base URL is empty")
 	}
 
 	if params.Token == "" {
-		return fmt.Errorf("API token is empty")
+		return "", fmt.Errorf("API token is empty")
 	}
 
 	if len(params.CacheKeys) == 0 {
-		return fmt.Errorf("cache key list is empty")
+		return "", fmt.Errorf("cache key list is empty")
 	}
 
 	client := newAPIClient(retryhttp.NewClient(logger), params.APIBaseURL, params.Token)
 
 	logger.Debugf("Get download URL")
-	url, err := client.restore(params.CacheKeys)
+	restoreResponse, err := client.restore(params.CacheKeys)
 	if err != nil {
-		return fmt.Errorf("failed to get download URL: %w", err)
+		return "", fmt.Errorf("failed to get download URL: %w", err)
 	}
 
 	logger.Debugf("Download archive")
 	file, err := os.Create(params.DownloadPath)
 	if err != nil {
-		return fmt.Errorf("can't open download location: %w", err)
+		return "", fmt.Errorf("can't open download location: %w", err)
 	}
 	defer func(file *os.File) {
 		err := file.Close()
@@ -56,9 +56,9 @@ func Download(params DownloadParams, logger log.Logger) error {
 		}
 	}(file)
 
-	respBody, err := client.downloadArchive(url)
+	respBody, err := client.downloadArchive(restoreResponse.URL)
 	if err != nil {
-		return fmt.Errorf("failed to download archive: %w", err)
+		return "", fmt.Errorf("failed to download archive: %w", err)
 	}
 	defer func(respBody io.ReadCloser) {
 		err := respBody.Close()
@@ -68,8 +68,8 @@ func Download(params DownloadParams, logger log.Logger) error {
 	}(respBody)
 	_, err = io.Copy(file, respBody)
 	if err != nil {
-		return fmt.Errorf("failed to save archive to disk: %w", err)
+		return "", fmt.Errorf("failed to save archive to disk: %w", err)
 	}
 
-	return nil
+	return restoreResponse.MatchedKey, nil
 }

--- a/cache/restore.go
+++ b/cache/restore.go
@@ -100,6 +100,9 @@ func (r *restorer) Restore(input RestoreCacheInput) error {
 	tracker.logArchiveExtracted(extractionTime, len(config.Keys))
 
 	err = r.exposeCacheHit(result)
+	if err != nil {
+		return err
+	}
 
 	tracker.logRestoreResult(true, result.matchedKey, config.Keys)
 	tracker.wait()

--- a/cache/restore.go
+++ b/cache/restore.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/bitrise-io/go-steputils/tools"
 	"github.com/bitrise-io/go-steputils/v2/cache/compression"
 	"github.com/bitrise-io/go-steputils/v2/cache/keytemplate"
 	"github.com/bitrise-io/go-steputils/v2/cache/network"
@@ -41,6 +42,11 @@ type restorer struct {
 	logger  log.Logger
 }
 
+type downloadResult struct {
+	filePath   string
+	matchedKey string
+}
+
 // NewRestorer ...
 func NewRestorer(envRepo env.Repository, logger log.Logger) *restorer {
 	return &restorer{envRepo: envRepo, logger: logger}
@@ -58,15 +64,23 @@ func (r *restorer) Restore(input RestoreCacheInput) error {
 	r.logger.Println()
 	r.logger.Infof("Downloading archive...")
 	downloadStartTime := time.Now()
-	archivePath, err := r.download(config)
+	result, err := r.download(config)
 	if err != nil {
 		if errors.Is(err, network.ErrCacheNotFound) {
 			r.logger.Donef("No cache entry found for the provided key")
+			tracker.logRestoreResult(false, "", config.Keys)
+			tracker.wait()
 			return nil
 		}
 		return fmt.Errorf("download failed: %w", err)
 	}
-	fileInfo, err := os.Stat(archivePath)
+	if result.matchedKey == config.Keys[0] {
+		r.logger.Printf("Exact hit for first key")
+	} else {
+		r.logger.Printf("Cache hit for key: %s", result.matchedKey)
+	}
+
+	fileInfo, err := os.Stat(result.filePath)
 	if err != nil {
 		return err
 	}
@@ -78,14 +92,17 @@ func (r *restorer) Restore(input RestoreCacheInput) error {
 	r.logger.Println()
 	r.logger.Infof("Restoring archive...")
 	extractionStartTime := time.Now()
-	if err := compression.Decompress(archivePath, r.logger, r.envRepo); err != nil {
+	if err := compression.Decompress(result.filePath, r.logger, r.envRepo); err != nil {
 		return fmt.Errorf("failed to decompress cache archive: %w", err)
 	}
 	extractionTime := time.Since(extractionStartTime).Round(time.Second)
 	r.logger.Donef("Restored archive in %s", extractionTime)
 	tracker.logArchiveExtracted(extractionTime, len(config.Keys))
-	tracker.wait()
 
+	err = r.exposeCacheHit(result)
+
+	tracker.logRestoreResult(true, result.matchedKey, config.Keys)
+	tracker.wait()
 	return nil
 }
 
@@ -134,10 +151,10 @@ func (r *restorer) evaluateKeys(keys []string) ([]string, error) {
 	return evaluatedKeys, nil
 }
 
-func (r *restorer) download(config restoreCacheConfig) (string, error) {
+func (r *restorer) download(config restoreCacheConfig) (downloadResult, error) {
 	dir, err := os.MkdirTemp("", "restore-cache")
 	if err != nil {
-		return "", err
+		return downloadResult{}, err
 	}
 	name := fmt.Sprintf("cache-%s.tzst", time.Now().UTC().Format("20060102-150405"))
 	downloadPath := filepath.Join(dir, name)
@@ -148,12 +165,34 @@ func (r *restorer) download(config restoreCacheConfig) (string, error) {
 		CacheKeys:    config.Keys,
 		DownloadPath: downloadPath,
 	}
-	err = network.Download(params, r.logger)
+	matchedKey, err := network.Download(params, r.logger)
 	if err != nil {
-		return "", err
+		return downloadResult{}, err
 	}
 
 	r.logger.Debugf("Archive downloaded to %s", downloadPath)
 
-	return downloadPath, nil
+	return downloadResult{filePath: downloadPath, matchedKey: matchedKey}, nil
+}
+
+func (r *restorer) exposeCacheHit(result downloadResult) error {
+	if result.filePath == "" || result.matchedKey == "" {
+		return nil
+	}
+
+	checksum, err := checksumOfFile(result.filePath)
+	if err != nil {
+		return err
+	}
+
+	r.logger.Debugf("Exposing cache hit info:")
+	r.logger.Debugf("Matched key: %s", result.matchedKey)
+	r.logger.Debugf("Archive checksum: %s", checksum)
+
+	envKey := cacheHitEnvVarPrefix + result.matchedKey
+	err = tools.ExportEnvironmentWithEnvman(envKey, checksum)
+	if err != nil {
+		return err
+	}
+	return r.envRepo.Set(envKey, checksum)
 }

--- a/cache/save.go
+++ b/cache/save.go
@@ -81,6 +81,7 @@ func (s *saver) Save(input SaveCacheInput) error {
 	tracker := newStepTracker(input.StepId, s.envRepo, s.logger)
 
 	canSkipSave, reason := s.canSkipSave(input.Key, config.Key, input.SkipChecksumChecking)
+	s.logger.Println()
 	if canSkipSave {
 		s.logger.Donef("Cache save can be skipped, reason: %s", reason)
 		return nil
@@ -112,6 +113,7 @@ func (s *saver) Save(input SaveCacheInput) error {
 		// fail silently and continue
 	}
 	canSkipUpload, reason := s.canSkipUpload(config.Key, archiveChecksum)
+	s.logger.Println()
 	if canSkipUpload {
 		s.logger.Donef("Cache upload can be skipped, reason: %s", reason)
 		return nil

--- a/cache/save.go
+++ b/cache/save.go
@@ -25,6 +25,12 @@ type SaveCacheInput struct {
 	Verbose bool
 	Key     string
 	Paths   []string
+	// SkipChecksumChecking indicates that the cache key is enough for knowing the cache archive is different from
+	// another cache archive.
+	// This can be set to true if the cache key contains a checksum that changes when any of the cached files change.
+	// Example of such key: my-cache-key-{{ checksum "package-lock.json" }}
+	// Example where this is not true: my-cache-key-{{ .OS }}-{{ .Arch }}
+	SkipChecksumChecking bool
 }
 
 // Saver ...
@@ -74,6 +80,14 @@ func (s *saver) Save(input SaveCacheInput) error {
 
 	tracker := newStepTracker(input.StepId, s.envRepo, s.logger)
 
+	canSkipSave, reason := s.canSkipSave(input.Key, config.Key, input.SkipChecksumChecking)
+	if canSkipSave {
+		s.logger.Donef("Cache save can be skipped, reason: %s", reason)
+		return nil
+	} else {
+		s.logger.Infof("Can't skip saving the cache, reason: %s", reason)
+	}
+
 	s.logger.Println()
 	s.logger.Infof("Creating archive...")
 	compressionStartTime := time.Now()
@@ -91,6 +105,19 @@ func (s *saver) Save(input SaveCacheInput) error {
 	}
 	s.logger.Printf("Archive size: %s", units.HumanSizeWithPrecision(float64(fileInfo.Size()), 3))
 	s.logger.Debugf("Archive path: %s", archivePath)
+
+	archiveChecksum, err := checksumOfFile(archivePath)
+	if err != nil {
+		s.logger.Warnf(err.Error())
+		// fail silently and continue
+	}
+	canSkipUpload, reason := s.canSkipUpload(config.Key, archiveChecksum)
+	if canSkipUpload {
+		s.logger.Donef("Cache upload can be skipped, reason: %s", reason)
+		return nil
+	} else {
+		s.logger.Infof("Can't skip uploading the cache, reason: %s", reason)
+	}
 
 	s.logger.Println()
 	s.logger.Infof("Uploading archive...")

--- a/cache/save.go
+++ b/cache/save.go
@@ -25,12 +25,12 @@ type SaveCacheInput struct {
 	Verbose bool
 	Key     string
 	Paths   []string
-	// SkipChecksumChecking indicates that the cache key is enough for knowing the cache archive is different from
+	// IsKeyUnique indicates that the cache key is enough for knowing the cache archive is different from
 	// another cache archive.
 	// This can be set to true if the cache key contains a checksum that changes when any of the cached files change.
 	// Example of such key: my-cache-key-{{ checksum "package-lock.json" }}
 	// Example where this is not true: my-cache-key-{{ .OS }}-{{ .Arch }}
-	SkipChecksumChecking bool
+	IsKeyUnique bool
 }
 
 // Saver ...
@@ -80,7 +80,7 @@ func (s *saver) Save(input SaveCacheInput) error {
 
 	tracker := newStepTracker(input.StepId, s.envRepo, s.logger)
 
-	canSkipSave, reason := s.canSkipSave(input.Key, config.Key, input.SkipChecksumChecking)
+	canSkipSave, reason := s.canSkipSave(input.Key, config.Key, input.IsKeyUnique)
 	s.logger.Println()
 	if canSkipSave {
 		s.logger.Donef("Cache save can be skipped, reason: %s", reason)

--- a/cache/save_skip.go
+++ b/cache/save_skip.go
@@ -1,0 +1,58 @@
+package cache
+
+import "strings"
+
+func (s *saver) canSkipSave(keyTemplate, evaluatedKey string, onlyCheckCacheKey bool) (canSkip bool, reason string) {
+	if keyTemplate == evaluatedKey {
+		return false, "key is not dynamic; the expectation is that the same key is used for saving different cache contents over and over"
+	}
+
+	cacheHits := s.getCacheHits()
+	if len(cacheHits) == 0 {
+		return false, "no cache was restored in the workflow, creating a new cache entry"
+	}
+
+	if _, ok := cacheHits[evaluatedKey]; ok {
+		if onlyCheckCacheKey {
+			return true, "a cache with the same key was restored in the workflow, new cache would have the same content"
+		} else {
+			return false, "a cache with the same key was restored in the workflow, but contents might have changed since then"
+		}
+	}
+
+	return false, "there was no cache restore in the workflow with this key"
+}
+
+func (s *saver) canSkipUpload(newCacheKey, newCacheChecksum string) (canSkip bool, reason string) {
+	cacheHits := s.getCacheHits()
+
+	if len(cacheHits) == 0 {
+		return false, "no cache was restored in the workflow"
+	}
+
+	if cacheHits[newCacheKey] == newCacheChecksum {
+		return true, "new cache archive is the same as the restored one"
+	} else {
+		return false, "new cache archive doesn't match the restored one"
+	}
+}
+
+// Returns cache hit information exposed by previous restore cache steps.
+// The returned map's key is the restored cache key, and the value is the checksum of the cache archive
+func (s *saver) getCacheHits() map[string]string {
+	cacheHits := map[string]string{}
+	for _, e := range s.envRepo.List() {
+		envParts := strings.SplitN(e, "=", 2)
+		if len(envParts) < 2 {
+			continue
+		}
+		envKey := envParts[0]
+		envValue := envParts[1]
+
+		if strings.HasPrefix(envKey, cacheHitEnvVarPrefix) {
+			cacheKey := strings.TrimPrefix(envKey, cacheHitEnvVarPrefix)
+			cacheHits[cacheKey] = envValue
+		}
+	}
+	return cacheHits
+}

--- a/cache/save_skip.go
+++ b/cache/save_skip.go
@@ -1,6 +1,9 @@
 package cache
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 func (s *saver) canSkipSave(keyTemplate, evaluatedKey string, onlyCheckCacheKey bool) (canSkip bool, reason string) {
 	if keyTemplate == evaluatedKey {
@@ -20,7 +23,12 @@ func (s *saver) canSkipSave(keyTemplate, evaluatedKey string, onlyCheckCacheKey 
 		}
 	}
 
-	return false, "there was no cache restore in the workflow with this key"
+	otherKeys := []string{}
+	for k := range cacheHits {
+		otherKeys = append(otherKeys, k)
+	}
+	fullReason := fmt.Sprintf("there was no cache restore in the workflow with this key\nOther restored cache keys found:\n%s", strings.Join(otherKeys, "\n"))
+	return false, fullReason
 }
 
 func (s *saver) canSkipUpload(newCacheKey, newCacheChecksum string) (canSkip bool, reason string) {

--- a/cache/save_skip_test.go
+++ b/cache/save_skip_test.go
@@ -1,0 +1,163 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-utils/v2/pathutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_canSkipSave(t *testing.T) {
+	type args struct {
+		keyTemplate       string
+		evaluatedKey      string
+		onlyCheckCacheKey bool
+	}
+	tests := []struct {
+		name string
+		args args
+		envs map[string]string
+		want bool
+	}{
+		{
+			name: "No cache hit, dynamic key",
+			envs: map[string]string{
+				"BITRISE_GIT_COMMIT": "8d722f4cc4e70373bd0b42139fa428d43e0527f0",
+			},
+			args: args{
+				keyTemplate:       "my-cache-key-{{ .CommitHash }}",
+				evaluatedKey:      "my-cache-key-8d722f4cc4e70373bd0b42139fa428d43e0527f0",
+				onlyCheckCacheKey: true,
+			},
+			want: false,
+		},
+		{
+			name: "Cache hit on different keys",
+			envs: map[string]string{
+				"BITRISE_CACHE_HIT__gradle-cache": "9a30a503b2862c51c3c5acd7fbce2f1f784cf4658ccf8e87d5023a90c21c0714",
+				"BITRISE_GIT_COMMIT":              "8d722f4cc4e70373bd0b42139fa428d43e0527f0",
+				"BITRISE_CACHE_HIT__static-key":   "9a30a503b2862c51c3c5acd7fbce2f1f784cf4658ccf8e87d5023a90c21c0714",
+			},
+			args: args{
+				keyTemplate:       "npm-cache-{{ .CommitHash }}",
+				evaluatedKey:      "npm-cache-8d722f4cc4e70373bd0b42139fa428d43e0527f0",
+				onlyCheckCacheKey: true,
+			},
+			want: false,
+		},
+		{
+			name: "Cache hit on multiple keys, one is same key",
+			envs: map[string]string{
+				"BITRISE_CACHE_HIT__gradle-cache": "9a30a503b2862c51c3c5acd7fbce2f1f784cf4658ccf8e87d5023a90c21c0714",
+				"BITRISE_GIT_COMMIT":              "8d722f4cc4e70373bd0b42139fa428d43e0527f0",
+				"BITRISE_CACHE_HIT__my-key-8d722f4cc4e70373bd0b42139fa428d43e0527f0": "9a30a503b2862c51c3c5acd7fbce2f1f784cf4658ccf8e87d5023a90c21c0714",
+			},
+			args: args{
+				keyTemplate:       "my-key-{{ .CommitHash }}",
+				evaluatedKey:      "my-key-8d722f4cc4e70373bd0b42139fa428d43e0527f0",
+				onlyCheckCacheKey: true,
+			},
+			want: true,
+		},
+		{
+			name: "Cache hit on static key",
+			envs: map[string]string{
+				"BITRISE_CACHE_HIT__static-key": "9a30a503b2862c51c3c5acd7fbce2f1f784cf4658ccf8e87d5023a90c21c0714",
+			},
+			args: args{
+				keyTemplate:       "static-key",
+				evaluatedKey:      "static-key",
+				onlyCheckCacheKey: false,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envRepo := fakeEnvRepo{envVars: tt.envs}
+			s := &saver{
+				envRepo:      envRepo,
+				logger:       log.NewLogger(),
+				pathProvider: pathutil.NewPathProvider(),
+				pathModifier: pathutil.NewPathModifier(),
+				pathChecker:  pathutil.NewPathChecker(),
+			}
+			canSkipSave, _ := s.canSkipSave(tt.args.keyTemplate, tt.args.evaluatedKey, tt.args.onlyCheckCacheKey)
+			assert.Equalf(t, tt.want, canSkipSave, "canSkipSave(%v, %v, %v)", tt.args.keyTemplate, tt.args.evaluatedKey, tt.args.onlyCheckCacheKey)
+		})
+	}
+}
+
+func Test_canSkipUpload(t *testing.T) {
+	type args struct {
+		newCacheKey      string
+		newCacheChecksum string
+	}
+	tests := []struct {
+		name string
+		args args
+		envs map[string]string
+		want bool
+	}{
+		{
+			name: "No cache hit",
+			envs: map[string]string{},
+			args: args{
+				newCacheKey:      "my-cache-key-8d722f4cc4e70373bd0b42139fa428d43e0527f0",
+				newCacheChecksum: "9a30a503b2862c51c3c5acd7fbce2f1f784cf4658ccf8e87d5023a90c21c0714",
+			},
+			want: false,
+		},
+		{
+			name: "Cache hit on different keys",
+			envs: map[string]string{
+				"BITRISE_CACHE_HIT__gradle-cache": "9a30a503b2862c51c3c5acd7fbce2f1f784cf4658ccf8e87d5023a90c21c0714",
+				"BITRISE_CACHE_HIT__static-key":   "9a30a503b2862c51c3c5acd7fbce2f1f784cf4658ccf8e87d5023a90c21c0714",
+			},
+			args: args{
+				newCacheKey:      "npm-cache-8d722f4cc4e70373bd0b42139fa428d43e0527f0",
+				newCacheChecksum: "9a30a503b2862c51c3c5acd7fbce2f1f784cf4658ccf8e87d5023a90c21c0714",
+			},
+			want: false,
+		},
+		{
+			name: "Cache hit on same key, checksum matches",
+			envs: map[string]string{
+				"BITRISE_CACHE_HIT__gradle-cache":                                    "9a30a503b2862c51c3c5acd7fbce2f1f784cf4658ccf8e87d5023a90c21c0714",
+				"BITRISE_CACHE_HIT__my-key-8d722f4cc4e70373bd0b42139fa428d43e0527f0": "9a30a503b2862c51c3c5acd7fbce2f1f784cf4658ccf8e87d5023a90c21c0714",
+			},
+			args: args{
+				newCacheKey:      "my-key-8d722f4cc4e70373bd0b42139fa428d43e0527f0",
+				newCacheChecksum: "9a30a503b2862c51c3c5acd7fbce2f1f784cf4658ccf8e87d5023a90c21c0714",
+			},
+			want: true,
+		},
+		{
+			name: "Cache hit on same key, checksum is different",
+			envs: map[string]string{
+				"BITRISE_CACHE_HIT__gradle-cache":                                    "9a30a503b2862c51c3c5acd7fbce2f1f784cf4658ccf8e87d5023a90c21c0714",
+				"BITRISE_CACHE_HIT__my-key-8d722f4cc4e70373bd0b42139fa428d43e0527f0": "9a30a503b2862c51c3c5acd7fbce2f1f784cf4658ccf8e87d5023a90c21c0714",
+			},
+			args: args{
+				newCacheKey:      "my-key-8d722f4cc4e70373bd0b42139fa428d43e0527f0",
+				newCacheChecksum: "6717e97f16450f0a6bb02213484ee34dd67dcda51e8660de0a0388e77c131654",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envRepo := fakeEnvRepo{envVars: tt.envs}
+			s := &saver{
+				envRepo:      envRepo,
+				logger:       log.NewLogger(),
+				pathProvider: pathutil.NewPathProvider(),
+				pathModifier: pathutil.NewPathModifier(),
+				pathChecker:  pathutil.NewPathChecker(),
+			}
+			canSkipUpload, _ := s.canSkipUpload(tt.args.newCacheKey, tt.args.newCacheChecksum)
+			assert.Equalf(t, tt.want, canSkipUpload, "canSkipUpload(%v, %v)", tt.args.newCacheKey, tt.args.newCacheChecksum)
+		})
+	}
+}

--- a/cache/save_test.go
+++ b/cache/save_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -209,9 +210,9 @@ func (repo fakeEnvRepo) Unset(key string) error {
 }
 
 func (repo fakeEnvRepo) List() []string {
-	var values []string
-	for _, v := range repo.envVars {
-		values = append(values, v)
+	envs := []string{}
+	for k, v := range repo.envVars {
+		envs = append(envs, fmt.Sprintf("%s=%s", k, v))
 	}
-	return values
+	return envs
 }

--- a/cache/tracker.go
+++ b/cache/tracker.go
@@ -62,6 +62,19 @@ func (t *stepTracker) logArchiveExtracted(extractionTime time.Duration, keyCount
 	t.tracker.Enqueue("step_restore_cache_archive_extracted", properties)
 }
 
+func (t *stepTracker) logRestoreResult(isMatch bool, matchedKey string, evaluatedKeys []string) {
+	if len(evaluatedKeys) == 0 {
+		return
+	}
+
+	properties := analytics.Properties{
+		"is_match":             isMatch,
+		"is_first_key_matched": matchedKey == evaluatedKeys[0],
+		"key_count":            len(evaluatedKeys),
+	}
+	t.tracker.Enqueue("step_restore_cache_result", properties)
+}
+
 func (t *stepTracker) wait() {
 	t.tracker.Wait()
 }

--- a/integration/download_test.go
+++ b/integration/download_test.go
@@ -43,12 +43,15 @@ func TestSuccessfulDownload(t *testing.T) {
 		DownloadPath: downloadPath,
 	}
 	logger.EnableDebugLog(true)
-	err = network.Download(params, logger)
+	matchedKey, err := network.Download(params, logger)
 
 	// Then
 	if err != nil {
 		t.Errorf(err.Error())
 	}
+
+	assert.Equal(t, cacheKeys[0], matchedKey)
+
 	testFileBytes, err := ioutil.ReadFile(testFile)
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -79,9 +82,10 @@ func TestNotFoundDownload(t *testing.T) {
 		DownloadPath: downloadPath,
 	}
 	logger.EnableDebugLog(true)
-	err := network.Download(params, logger)
+	matchedKey, err := network.Download(params, logger)
 
 	// Then
+	assert.Equal(t, "", matchedKey)
 	assert.ErrorIs(t, err, network.ErrCacheNotFound)
 }
 


### PR DESCRIPTION
### Context

The full context and idea is described in [ACI-4](https://bitrise.atlassian.net/jira/software/c/projects/ACI/boards/280?modal=detail&selectedIssue=ACI-4)

### Changes

- The restore API endpoint now returns the exact matched key, surface this information in return values
- `Restorer` now exposes the matched key as an env var if there is a cache hit
- `Saver` checks these cache hit env vars and can decide to skip
  - both compression and upload
  - just upload if it needs to compute a checksum of the new archive to make sure it's the same as before
- log an event in `Restorer` with details about the key match

### Out of scope

Event logging in `Saver`. I want to beta test this whole logic in the wild to see what we want to log exactly and to figure out the best schema.