### PR TITLE
Track cache skip reasons

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
   - typecheck
   - unused
   - revive
+  - exhaustive
 
 linters-settings:
   revive:

--- a/cache/restore.go
+++ b/cache/restore.go
@@ -60,6 +60,7 @@ func (r *restorer) Restore(input RestoreCacheInput) error {
 	}
 
 	tracker := newStepTracker(input.StepId, r.envRepo, r.logger)
+	defer tracker.wait()
 
 	r.logger.Println()
 	r.logger.Infof("Downloading archive...")
@@ -69,7 +70,6 @@ func (r *restorer) Restore(input RestoreCacheInput) error {
 		if errors.Is(err, network.ErrCacheNotFound) {
 			r.logger.Donef("No cache entry found for the provided key")
 			tracker.logRestoreResult(false, "", config.Keys)
-			tracker.wait()
 			return nil
 		}
 		return fmt.Errorf("download failed: %w", err)
@@ -105,7 +105,6 @@ func (r *restorer) Restore(input RestoreCacheInput) error {
 	}
 
 	tracker.logRestoreResult(true, result.matchedKey, config.Keys)
-	tracker.wait()
 	return nil
 }
 

--- a/cache/restore_test.go
+++ b/cache/restore_test.go
@@ -197,7 +197,7 @@ func Test_exposeCacheHit(t *testing.T) {
 				logger:  log.NewLogger(),
 			}
 			if err := r.exposeCacheHit(tt.downloadResult); (err != nil) != tt.wantErr {
-				t.Errorf("exposeCacheHit() error = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("exposeCacheHit() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			assert.Equal(t, tt.wantEnvs, envRepo.List())
 		})

--- a/cache/save.go
+++ b/cache/save.go
@@ -79,14 +79,19 @@ func (s *saver) Save(input SaveCacheInput) error {
 	}
 
 	tracker := newStepTracker(input.StepId, s.envRepo, s.logger)
+	defer tracker.wait()
 
 	canSkipSave, reason := s.canSkipSave(input.Key, config.Key, input.IsKeyUnique)
+	tracker.logSkipSaveResult(canSkipSave, reason)
 	s.logger.Println()
 	if canSkipSave {
-		s.logger.Donef("Cache save can be skipped, reason: %s", reason)
+		s.logger.Donef("Cache save can be skipped, reason: %s", reason.description())
 		return nil
 	} else {
-		s.logger.Infof("Can't skip saving the cache, reason: %s", reason)
+		s.logger.Infof("Can't skip saving the cache, reason: %s", reason.description())
+		if reason == reasonRestoreOtherKey {
+			s.logOtherHits()
+		}
 	}
 
 	s.logger.Println()
@@ -113,13 +118,13 @@ func (s *saver) Save(input SaveCacheInput) error {
 		// fail silently and continue
 	}
 	canSkipUpload, reason := s.canSkipUpload(config.Key, archiveChecksum)
+	tracker.logSkipUploadResult(canSkipUpload, reason)
 	s.logger.Println()
 	if canSkipUpload {
-		s.logger.Donef("Cache upload can be skipped, reason: %s", reason)
+		s.logger.Donef("Cache upload can be skipped, reason: %s", reason.description())
 		return nil
-	} else {
-		s.logger.Infof("Can't skip uploading the cache, reason: %s", reason)
 	}
+	s.logger.Infof("Can't skip uploading the cache, reason: %s", reason.description())
 
 	s.logger.Println()
 	s.logger.Infof("Uploading archive...")
@@ -131,7 +136,6 @@ func (s *saver) Save(input SaveCacheInput) error {
 	uploadTime := time.Since(uploadStartTime).Round(time.Second)
 	s.logger.Donef("Archive uploaded in %s", uploadTime)
 	tracker.logArchiveUploaded(uploadTime, fileInfo, len(config.Paths))
-	tracker.wait()
 
 	return nil
 }

--- a/cache/save.go
+++ b/cache/save.go
@@ -89,7 +89,7 @@ func (s *saver) Save(input SaveCacheInput) error {
 		return nil
 	} else {
 		s.logger.Infof("Can't skip saving the cache, reason: %s", reason.description())
-		if reason == reasonRestoreOtherKey {
+		if reason == reasonNoRestoreThisKey {
 			s.logOtherHits()
 		}
 	}

--- a/cache/save_skip.go
+++ b/cache/save_skip.go
@@ -11,7 +11,7 @@ const (
 	reasonNoRestore
 	reasonRestoreSameUniqueKey
 	reasonRestoreSameKeyNotUnique
-	reasonRestoreOtherKey
+	reasonNoRestoreThisKey
 	reasonNewArchiveChecksumMatch
 	reasonNewArchiveChecksumMismatch
 )
@@ -26,8 +26,8 @@ func (r skipReason) String() string {
 		return "restore_same_unique_key"
 	case reasonRestoreSameKeyNotUnique:
 		return "restore_same_key_not_unique"
-	case reasonRestoreOtherKey:
-		return "restore_other_key"
+	case reasonNoRestoreThisKey:
+		return "no_restore_with_this_key"
 	case reasonNewArchiveChecksumMatch:
 		return "new_archive_checksum_match"
 	case reasonNewArchiveChecksumMismatch:
@@ -47,8 +47,8 @@ func (r skipReason) description() string {
 		return "a cache with the same key was restored in the workflow, new cache would have the same content"
 	case reasonRestoreSameKeyNotUnique:
 		return "a cache with the same key was restored in the workflow, but contents might have changed since then"
-	case reasonRestoreOtherKey:
-		return "there was no cache restore in the workflow with this key"
+	case reasonNoRestoreThisKey:
+		return "there was no cache restore in the workflow with this key, but was for other(s)"
 	case reasonNewArchiveChecksumMatch:
 		return "new cache archive is the same as the restored one"
 	case reasonNewArchiveChecksumMismatch:
@@ -76,7 +76,7 @@ func (s *saver) canSkipSave(keyTemplate, evaluatedKey string, isKeyUnique bool) 
 		}
 	}
 
-	return false, reasonRestoreOtherKey
+	return false, reasonNoRestoreThisKey
 }
 
 func (s *saver) canSkipUpload(newCacheKey, newCacheChecksum string) (bool, skipReason) {
@@ -88,7 +88,7 @@ func (s *saver) canSkipUpload(newCacheKey, newCacheChecksum string) (bool, skipR
 
 	checksumForNewKey, ok := cacheHits[newCacheKey]
 	if !ok {
-		return false, reasonRestoreOtherKey
+		return false, reasonNoRestoreThisKey
 	}
 	if checksumForNewKey == newCacheChecksum {
 		return true, reasonNewArchiveChecksumMatch

--- a/cache/save_skip.go
+++ b/cache/save_skip.go
@@ -1,48 +1,100 @@
 package cache
 
 import (
-	"fmt"
 	"strings"
 )
 
-func (s *saver) canSkipSave(keyTemplate, evaluatedKey string, onlyCheckCacheKey bool) (canSkip bool, reason string) {
+type skipReason int
+
+const (
+	reasonKeyNotDynamic skipReason = iota
+	reasonNoRestore
+	reasonRestoreSameUniqueKey
+	reasonRestoreSameKeyNotUnique
+	reasonRestoreOtherKey
+	reasonNewArchiveChecksumMatch
+	reasonNewArchiveChecksumMismatch
+)
+
+func (r skipReason) String() string {
+	switch r {
+	case reasonKeyNotDynamic:
+		return "key_not_dynamic"
+	case reasonNoRestore:
+		return "no_restore_found"
+	case reasonRestoreSameUniqueKey:
+		return "restore_same_unique_key"
+	case reasonRestoreSameKeyNotUnique:
+		return "restore_same_key_not_unique"
+	case reasonRestoreOtherKey:
+		return "restore_other_key"
+	case reasonNewArchiveChecksumMatch:
+		return "new_archive_checksum_match"
+	case reasonNewArchiveChecksumMismatch:
+		return "new_archive_checksum_mismatch"
+	default:
+		return "unknown"
+	}
+}
+
+func (r skipReason) description() string {
+	switch r {
+	case reasonKeyNotDynamic:
+		return "key is not dynamic; the expectation is that the same key is used for saving different cache contents over and over"
+	case reasonNoRestore:
+		return "no cache was restored in the workflow, creating a new cache entry"
+	case reasonRestoreSameUniqueKey:
+		return "a cache with the same key was restored in the workflow, new cache would have the same content"
+	case reasonRestoreSameKeyNotUnique:
+		return "a cache with the same key was restored in the workflow, but contents might have changed since then"
+	case reasonRestoreOtherKey:
+		return "there was no cache restore in the workflow with this key"
+	case reasonNewArchiveChecksumMatch:
+		return "new cache archive is the same as the restored one"
+	case reasonNewArchiveChecksumMismatch:
+		return "new cache archive doesn't match the restored one"
+	default:
+		return "unrecognized skipReason"
+	}
+}
+
+func (s *saver) canSkipSave(keyTemplate, evaluatedKey string, isKeyUnique bool) (bool, skipReason) {
 	if keyTemplate == evaluatedKey {
-		return false, "key is not dynamic; the expectation is that the same key is used for saving different cache contents over and over"
+		return false, reasonKeyNotDynamic
 	}
 
 	cacheHits := s.getCacheHits()
 	if len(cacheHits) == 0 {
-		return false, "no cache was restored in the workflow, creating a new cache entry"
+		return false, reasonNoRestore
 	}
 
 	if _, ok := cacheHits[evaluatedKey]; ok {
-		if onlyCheckCacheKey {
-			return true, "a cache with the same key was restored in the workflow, new cache would have the same content"
+		if isKeyUnique {
+			return true, reasonRestoreSameUniqueKey
 		} else {
-			return false, "a cache with the same key was restored in the workflow, but contents might have changed since then"
+			return false, reasonRestoreSameKeyNotUnique
 		}
 	}
 
-	otherKeys := []string{}
-	for k := range cacheHits {
-		otherKeys = append(otherKeys, k)
-	}
-	fullReason := fmt.Sprintf("there was no cache restore in the workflow with this key\nOther restored cache keys found:\n%s", strings.Join(otherKeys, "\n"))
-	return false, fullReason
+	return false, reasonRestoreOtherKey
 }
 
-func (s *saver) canSkipUpload(newCacheKey, newCacheChecksum string) (canSkip bool, reason string) {
+func (s *saver) canSkipUpload(newCacheKey, newCacheChecksum string) (bool, skipReason) {
 	cacheHits := s.getCacheHits()
 
 	if len(cacheHits) == 0 {
-		return false, "no cache was restored in the workflow"
+		return false, reasonNoRestore
 	}
 
-	if cacheHits[newCacheKey] == newCacheChecksum {
-		return true, "new cache archive is the same as the restored one"
-	} else {
-		return false, "new cache archive doesn't match the restored one"
+	checksumForNewKey, ok := cacheHits[newCacheKey]
+	if !ok {
+		return false, reasonRestoreOtherKey
 	}
+	if checksumForNewKey == newCacheChecksum {
+		return true, reasonNewArchiveChecksumMatch
+	}
+
+	return false, reasonNewArchiveChecksumMismatch
 }
 
 // Returns cache hit information exposed by previous restore cache steps.
@@ -63,4 +115,16 @@ func (s *saver) getCacheHits() map[string]string {
 		}
 	}
 	return cacheHits
+}
+
+func (s *saver) logOtherHits() {
+	otherKeys := []string{}
+	for k := range s.getCacheHits() {
+		otherKeys = append(otherKeys, k)
+	}
+	if len(otherKeys) == 0 {
+		return
+	}
+	s.logger.Printf("Other restored cache keys:")
+	s.logger.Printf(strings.Join(otherKeys, "\n"))
 }

--- a/cache/save_skip_test.go
+++ b/cache/save_skip_test.go
@@ -47,7 +47,7 @@ func Test_canSkipSave(t *testing.T) {
 				onlyCheckCacheKey: true,
 			},
 			want:       false,
-			wantReason: reasonRestoreOtherKey,
+			wantReason: reasonNoRestoreThisKey,
 		},
 		{
 			name: "Cache hit on multiple keys, one is same key",
@@ -128,7 +128,7 @@ func Test_canSkipUpload(t *testing.T) {
 				newCacheChecksum: "9a30a503b2862c51c3c5acd7fbce2f1f784cf4658ccf8e87d5023a90c21c0714",
 			},
 			want:       false,
-			wantReason: reasonRestoreOtherKey,
+			wantReason: reasonNoRestoreThisKey,
 		},
 		{
 			name: "Cache hit on same key, checksum matches",

--- a/cache/save_skip_test.go
+++ b/cache/save_skip_test.go
@@ -15,10 +15,11 @@ func Test_canSkipSave(t *testing.T) {
 		onlyCheckCacheKey bool
 	}
 	tests := []struct {
-		name string
-		args args
-		envs map[string]string
-		want bool
+		name       string
+		args       args
+		envs       map[string]string
+		want       bool
+		wantReason skipReason
 	}{
 		{
 			name: "No cache hit, dynamic key",
@@ -30,7 +31,8 @@ func Test_canSkipSave(t *testing.T) {
 				evaluatedKey:      "my-cache-key-8d722f4cc4e70373bd0b42139fa428d43e0527f0",
 				onlyCheckCacheKey: true,
 			},
-			want: false,
+			want:       false,
+			wantReason: reasonNoRestore,
 		},
 		{
 			name: "Cache hit on different keys",
@@ -44,7 +46,8 @@ func Test_canSkipSave(t *testing.T) {
 				evaluatedKey:      "npm-cache-8d722f4cc4e70373bd0b42139fa428d43e0527f0",
 				onlyCheckCacheKey: true,
 			},
-			want: false,
+			want:       false,
+			wantReason: reasonRestoreOtherKey,
 		},
 		{
 			name: "Cache hit on multiple keys, one is same key",
@@ -58,7 +61,8 @@ func Test_canSkipSave(t *testing.T) {
 				evaluatedKey:      "my-key-8d722f4cc4e70373bd0b42139fa428d43e0527f0",
 				onlyCheckCacheKey: true,
 			},
-			want: true,
+			want:       true,
+			wantReason: reasonRestoreSameUniqueKey,
 		},
 		{
 			name: "Cache hit on static key",
@@ -70,7 +74,8 @@ func Test_canSkipSave(t *testing.T) {
 				evaluatedKey:      "static-key",
 				onlyCheckCacheKey: false,
 			},
-			want: false,
+			want:       false,
+			wantReason: reasonKeyNotDynamic,
 		},
 	}
 	for _, tt := range tests {
@@ -83,8 +88,9 @@ func Test_canSkipSave(t *testing.T) {
 				pathModifier: pathutil.NewPathModifier(),
 				pathChecker:  pathutil.NewPathChecker(),
 			}
-			canSkipSave, _ := s.canSkipSave(tt.args.keyTemplate, tt.args.evaluatedKey, tt.args.onlyCheckCacheKey)
+			canSkipSave, reason := s.canSkipSave(tt.args.keyTemplate, tt.args.evaluatedKey, tt.args.onlyCheckCacheKey)
 			assert.Equalf(t, tt.want, canSkipSave, "canSkipSave(%v, %v, %v)", tt.args.keyTemplate, tt.args.evaluatedKey, tt.args.onlyCheckCacheKey)
+			assert.Equalf(t, tt.wantReason.String(), reason.String(), "canSkipSave(%v, %v, %v)", tt.args.keyTemplate, tt.args.evaluatedKey, tt.args.onlyCheckCacheKey)
 		})
 	}
 }
@@ -95,10 +101,11 @@ func Test_canSkipUpload(t *testing.T) {
 		newCacheChecksum string
 	}
 	tests := []struct {
-		name string
-		args args
-		envs map[string]string
-		want bool
+		name       string
+		args       args
+		envs       map[string]string
+		want       bool
+		wantReason skipReason
 	}{
 		{
 			name: "No cache hit",
@@ -107,7 +114,8 @@ func Test_canSkipUpload(t *testing.T) {
 				newCacheKey:      "my-cache-key-8d722f4cc4e70373bd0b42139fa428d43e0527f0",
 				newCacheChecksum: "9a30a503b2862c51c3c5acd7fbce2f1f784cf4658ccf8e87d5023a90c21c0714",
 			},
-			want: false,
+			want:       false,
+			wantReason: reasonNoRestore,
 		},
 		{
 			name: "Cache hit on different keys",
@@ -119,7 +127,8 @@ func Test_canSkipUpload(t *testing.T) {
 				newCacheKey:      "npm-cache-8d722f4cc4e70373bd0b42139fa428d43e0527f0",
 				newCacheChecksum: "9a30a503b2862c51c3c5acd7fbce2f1f784cf4658ccf8e87d5023a90c21c0714",
 			},
-			want: false,
+			want:       false,
+			wantReason: reasonRestoreOtherKey,
 		},
 		{
 			name: "Cache hit on same key, checksum matches",
@@ -131,7 +140,8 @@ func Test_canSkipUpload(t *testing.T) {
 				newCacheKey:      "my-key-8d722f4cc4e70373bd0b42139fa428d43e0527f0",
 				newCacheChecksum: "9a30a503b2862c51c3c5acd7fbce2f1f784cf4658ccf8e87d5023a90c21c0714",
 			},
-			want: true,
+			want:       true,
+			wantReason: reasonNewArchiveChecksumMatch,
 		},
 		{
 			name: "Cache hit on same key, checksum is different",
@@ -143,7 +153,8 @@ func Test_canSkipUpload(t *testing.T) {
 				newCacheKey:      "my-key-8d722f4cc4e70373bd0b42139fa428d43e0527f0",
 				newCacheChecksum: "6717e97f16450f0a6bb02213484ee34dd67dcda51e8660de0a0388e77c131654",
 			},
-			want: false,
+			want:       false,
+			wantReason: reasonNewArchiveChecksumMismatch,
 		},
 	}
 	for _, tt := range tests {
@@ -156,8 +167,9 @@ func Test_canSkipUpload(t *testing.T) {
 				pathModifier: pathutil.NewPathModifier(),
 				pathChecker:  pathutil.NewPathChecker(),
 			}
-			canSkipUpload, _ := s.canSkipUpload(tt.args.newCacheKey, tt.args.newCacheChecksum)
+			canSkipUpload, reason := s.canSkipUpload(tt.args.newCacheKey, tt.args.newCacheChecksum)
 			assert.Equalf(t, tt.want, canSkipUpload, "canSkipUpload(%v, %v)", tt.args.newCacheKey, tt.args.newCacheChecksum)
+			assert.Equalf(t, tt.wantReason.String(), reason.String(), "canSkipUpload(%v, %v)", tt.args.newCacheKey, tt.args.newCacheChecksum)
 		})
 	}
 }

--- a/cache/tracker.go
+++ b/cache/tracker.go
@@ -75,6 +75,24 @@ func (t *stepTracker) logRestoreResult(isMatch bool, matchedKey string, evaluate
 	t.tracker.Enqueue("step_restore_cache_result", properties)
 }
 
+func (t *stepTracker) logSkipSaveResult(isSaveSkipped bool, reason skipReason) {
+
+	properties := analytics.Properties{
+		"is_save_skipped": isSaveSkipped,
+		"reason":          reason.String(),
+	}
+	t.tracker.Enqueue("step_save_cache_save_skipped", properties)
+}
+
+func (t *stepTracker) logSkipUploadResult(isUploadSkipped bool, reason skipReason) {
+
+	properties := analytics.Properties{
+		"is_upload_skipped": isUploadSkipped,
+		"reason":            reason.String(),
+	}
+	t.tracker.Enqueue("step_save_cache_upload_skipped", properties)
+}
+
 func (t *stepTracker) wait() {
 	t.tracker.Wait()
 }

--- a/stepconf/stepconf.go
+++ b/stepconf/stepconf.go
@@ -86,7 +86,7 @@ func setField(field reflect.Value, value, constraint string) error {
 		field = field.Elem()
 	}
 
-	switch field.Kind() {
+	switch field.Kind() { //nolint:exhaustive
 	case reflect.String:
 		field.SetString(value)
 	case reflect.Bool:


### PR DESCRIPTION
### Context

Follow-up to #67, this PR adds tracking when we can skip saving the cache altogether and when we can only skip the upload.

### Changes

- Log new events with the skip result and reason
- Refactor the skip reason handling with enums
- Enable the `exhaustive` linter in order to check `switch` expressions on enums
- Adjust tests
- Smaller adjustments here and there