### PR TITLE
Update cache API token handling

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -48,7 +48,7 @@ workflows:
             set -e
 
             json_response=$(curl --fail -X POST https://auth.services.bitrise.io/auth/realms/bitrise-services/protocol/openid-connect/token -k \
-                --data "client_id=abcs-steps" \
+                --data "client_id=bitrise-steps" \
                 --data "client_secret=$CACHE_API_CLIENT_SECRET" \
                 --data "grant_type=urn:ietf:params:oauth:grant-type:uma-ticket" \
                 --data "claim_token=eyJhcHBfaWQiOlsic3RlcC1zYXZlLWNhY2hlLWUyZS10ZXN0cyJdLCAiYWNjZXNzX2dyYW50ZWQiOlsidHJ1ZSJdfQ==" \

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -58,4 +58,4 @@ workflows:
             auth_token=$(echo $json_response | jq -r .access_token)
 
             envman add --key BITRISEIO_ABCS_API_URL --value $CACHE_API_URL
-            envman add --key BITRISEIO_ABCS_ACCESS_TOKEN --value $auth_token --sensitive
+            envman add --key BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN --value $auth_token --sensitive

--- a/cache/restore.go
+++ b/cache/restore.go
@@ -113,9 +113,9 @@ func (r *restorer) createConfig(input RestoreCacheInput) (restoreCacheConfig, er
 	if apiBaseURL == "" {
 		return restoreCacheConfig{}, fmt.Errorf("the secret 'BITRISEIO_ABCS_API_URL' is not defined")
 	}
-	apiAccessToken := r.envRepo.Get("BITRISEIO_ABCS_ACCESS_TOKEN")
+	apiAccessToken := r.envRepo.Get("BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN")
 	if apiAccessToken == "" {
-		return restoreCacheConfig{}, fmt.Errorf("the secret 'BITRISEIO_ABCS_ACCESS_TOKEN' is not defined")
+		return restoreCacheConfig{}, fmt.Errorf("the secret 'BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN' is not defined")
 	}
 
 	keys, err := r.evaluateKeys(input.Keys)

--- a/cache/restore_test.go
+++ b/cache/restore_test.go
@@ -54,8 +54,8 @@ func Test_ProcessRestoreConfig(t *testing.T) {
 			step := restorer{
 				logger: log.NewLogger(),
 				envRepo: fakeEnvRepo{envVars: map[string]string{
-					"BITRISEIO_ABCS_API_URL":      "fake service URL",
-					"BITRISEIO_ABCS_ACCESS_TOKEN": "fake access token",
+					"BITRISEIO_ABCS_API_URL":                  "fake service URL",
+					"BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN": "fake access token",
 				}},
 			}
 

--- a/cache/save.go
+++ b/cache/save.go
@@ -162,9 +162,9 @@ func (s *saver) createConfig(input SaveCacheInput) (saveCacheConfig, error) {
 	if apiBaseURL == "" {
 		return saveCacheConfig{}, fmt.Errorf("the secret 'BITRISEIO_ABCS_API_URL' is not defined")
 	}
-	apiAccessToken := s.envRepo.Get("BITRISEIO_ABCS_ACCESS_TOKEN")
+	apiAccessToken := s.envRepo.Get("BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN")
 	if apiAccessToken == "" {
-		return saveCacheConfig{}, fmt.Errorf("the secret 'BITRISEIO_ABCS_ACCESS_TOKEN' is not defined")
+		return saveCacheConfig{}, fmt.Errorf("the secret 'BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN' is not defined")
 	}
 
 	return saveCacheConfig{

--- a/cache/save_test.go
+++ b/cache/save_test.go
@@ -116,9 +116,9 @@ func Test_ProcessSaveConfig(t *testing.T) {
 				pathProvider: pathutil.NewPathProvider(),
 				pathModifier: pathutil.NewPathModifier(),
 				envRepo: fakeEnvRepo{envVars: map[string]string{
-					"BITRISEIO_ABCS_API_URL":      "fake cache service URL",
-					"BITRISEIO_ABCS_ACCESS_TOKEN": "fake cache service access token",
-					"INTEGRATION_TEST_ENV":        "test_value",
+					"BITRISEIO_ABCS_API_URL":                  "fake cache service URL",
+					"BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN": "fake cache service access token",
+					"INTEGRATION_TEST_ENV":                    "test_value",
 				}},
 			}
 			got, err := step.createConfig(tt.input)

--- a/integration/download_test.go
+++ b/integration/download_test.go
@@ -26,7 +26,7 @@ func TestSuccessfulDownload(t *testing.T) {
 		strings.Repeat("cache-key-", 60),
 	}
 	baseURL := os.Getenv("BITRISEIO_ABCS_API_URL")
-	token := os.Getenv("BITRISEIO_ABCS_ACCESS_TOKEN")
+	token := os.Getenv("BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN")
 	testFile := "testdata/single-item.tzst"
 
 	err := uploadArchive(cacheKeys[0], testFile, baseURL, token)
@@ -71,7 +71,7 @@ func TestNotFoundDownload(t *testing.T) {
 		fmt.Sprintf("no-cache-for-this-%d", rand.Int()),
 	}
 	baseURL := os.Getenv("BITRISEIO_ABCS_API_URL")
-	token := os.Getenv("BITRISEIO_ABCS_ACCESS_TOKEN")
+	token := os.Getenv("BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN")
 
 	// When
 	downloadPath := filepath.Join(t.TempDir(), "cache-test.tzst")

--- a/integration/upload_test.go
+++ b/integration/upload_test.go
@@ -22,7 +22,7 @@ func TestUpload(t *testing.T) {
 	// Given
 	cacheKey := "integration-test"
 	baseURL := os.Getenv("BITRISEIO_ABCS_API_URL")
-	token := os.Getenv("BITRISEIO_ABCS_ACCESS_TOKEN")
+	token := os.Getenv("BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN")
 	testFile := "testdata/single-item.tzst"
 	params := network.UploadParams{
 		APIBaseURL:  baseURL,


### PR DESCRIPTION
Update the cache API token handling throughout the code with the new env key (this is injected into the VM automatically).