### PR TITLE
Add asdf support to v1 of go-steputils

### DIFF
--- a/command/rubycommand/rubycommand.go
+++ b/command/rubycommand/rubycommand.go
@@ -33,6 +33,8 @@ const (
 	RVMRuby
 	// RbenvRuby ...
 	RbenvRuby
+	// ASDFRuby ...
+	ASDFRuby
 )
 
 func cmdExist(slice ...string) bool {
@@ -66,6 +68,13 @@ func RubyInstallType() InstallType {
 		installType = RVMRuby
 	} else if cmdExist("rbenv", "-v") {
 		installType = RbenvRuby
+	} else if cmdExist("asdf") {
+		// asdf doesn't store its installs in a definite location,
+		// but it does store its shims in a 'shims' directory, which
+		// is what we'll get from the `which ruby` call above.
+		if strings.Contains(whichRuby, "shims/ruby") {
+			installType = ASDFRuby
+		}
 	}
 
 	return installType
@@ -146,7 +155,12 @@ func GemUpdate(gem string) ([]*command.Model, error) {
 		if err != nil {
 			return []*command.Model{}, err
 		}
-
+		cmds = append(cmds, cmd)
+	} else if rubyInstallType == ASDFRuby {
+		cmd, err := New("asdf", "reshim", "ruby")
+		if err != nil {
+			return []*command.Model{}, err
+		}
 		cmds = append(cmds, cmd)
 	}
 
@@ -180,7 +194,12 @@ func GemInstall(gem, version string, enablePrerelease bool) ([]*command.Model, e
 		if err != nil {
 			return []*command.Model{}, err
 		}
-
+		cmds = append(cmds, cmd)
+	} else if rubyInstallType == ASDFRuby {
+		cmd, err := New("asdf", "reshim", "ruby")
+		if err != nil {
+			return []*command.Model{}, err
+		}
 		cmds = append(cmds, cmd)
 	}
 
@@ -273,4 +292,48 @@ func IsSpecifiedRbenvRubyInstalled(workdir string) (bool, string, error) {
 		log.Warnf("failed to check installed ruby version, %s error: %s", out, err)
 	}
 	return isSpecifiedRbenvRubyInstalled(out)
+}
+
+func isSpecifiedASDFRubyInstalled(message string) (isInstalled bool, versionInstalled string, error error) {
+	//
+	// Not installed
+	regexPattern := "Not installed. Run \"asdf install ruby .*\""
+	reg, err := regexp.Compile(regexPattern)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to parse regex ( %s ) on the error message, error: %s", regexPattern, err)
+	}
+
+	var version string
+	if reg.MatchString(message) {
+		//
+		// Not installed
+		version = strings.Split(strings.Split(message, "asdf install ruby ")[1], "\"")[0]
+		return false, version, nil
+	}
+
+	//
+	// Installed
+	patternTerminator := "/"
+	if strings.Contains(message, "ASDF_RUBY_VERSION") {
+		patternTerminator = "ASDF_RUBY_VERSION"
+	}
+
+	version = strings.Split(strings.Split(message, "ruby ")[1], patternTerminator)[0]
+	version = strings.TrimSpace(version)
+	return true, version, nil
+}
+
+func IsSpecifiedASDFRubyInstalled(workdir string) (isInstalled bool, versionInstalled string, error error) {
+	absWorkdir, err := pathutil.AbsPath(workdir)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to get absolute path for ( %s ), error: %s", workdir, err)
+	}
+
+	cmd := command.New("asdf", "current", "ruby").SetDir(absWorkdir)
+	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	if err != nil {
+		log.Warnf("failed to check installed ruby version, %s error: %s", out, err)
+	}
+
+	return isSpecifiedASDFRubyInstalled(out)
 }

--- a/command/rubycommand/rubycommand_test.go
+++ b/command/rubycommand/rubycommand_test.go
@@ -26,6 +26,7 @@ func TestSudoNeeded(t *testing.T) {
 		require.Equal(t, false, sudoNeeded(BrewRuby, "ls"))
 		require.Equal(t, false, sudoNeeded(RVMRuby, "ls"))
 		require.Equal(t, false, sudoNeeded(RbenvRuby, "ls"))
+		require.Equal(t, false, sudoNeeded(ASDFRuby, "ls"))
 	}
 
 	t.Log("sudo needed for SystemRuby in case of gem list management command")
@@ -35,12 +36,14 @@ func TestSudoNeeded(t *testing.T) {
 		require.Equal(t, false, sudoNeeded(BrewRuby, "gem", "install", "fastlane"))
 		require.Equal(t, false, sudoNeeded(RVMRuby, "gem", "install", "fastlane"))
 		require.Equal(t, false, sudoNeeded(RbenvRuby, "gem", "install", "fastlane"))
+		require.Equal(t, false, sudoNeeded(ASDFRuby, "gem", "install", "fastlane"))
 
 		require.Equal(t, false, sudoNeeded(Unkown, "gem", "uninstall", "fastlane"))
 		require.Equal(t, true, sudoNeeded(SystemRuby, "gem", "uninstall", "fastlane"))
 		require.Equal(t, false, sudoNeeded(BrewRuby, "gem", "uninstall", "fastlane"))
 		require.Equal(t, false, sudoNeeded(RVMRuby, "gem", "uninstall", "fastlane"))
 		require.Equal(t, false, sudoNeeded(RbenvRuby, "gem", "uninstall", "fastlane"))
+		require.Equal(t, false, sudoNeeded(ASDFRuby, "gem", "uninstall", "fastlane"))
 
 		require.Equal(t, false, sudoNeeded(Unkown, "bundle", "install"))
 		require.Equal(t, false, sudoNeeded(Unkown, "bundle", "_2.0.2_", "install"))
@@ -50,6 +53,7 @@ func TestSudoNeeded(t *testing.T) {
 		require.Equal(t, false, sudoNeeded(BrewRuby, "bundle", "install"))
 		require.Equal(t, false, sudoNeeded(RVMRuby, "bundle", "install"))
 		require.Equal(t, false, sudoNeeded(RbenvRuby, "bundle", "install"))
+		require.Equal(t, false, sudoNeeded(ASDFRuby, "bundle", "install"))
 
 		require.Equal(t, false, sudoNeeded(Unkown, "bundle", "update"))
 		require.Equal(t, false, sudoNeeded(Unkown, "bundle", "_2.0.2_", "update"))
@@ -58,6 +62,7 @@ func TestSudoNeeded(t *testing.T) {
 		require.Equal(t, false, sudoNeeded(BrewRuby, "bundle", "update"))
 		require.Equal(t, false, sudoNeeded(RVMRuby, "bundle", "update"))
 		require.Equal(t, false, sudoNeeded(RbenvRuby, "bundle", "update"))
+		require.Equal(t, false, sudoNeeded(ASDFRuby, "bundle", "update"))
 	}
 }
 
@@ -192,6 +197,45 @@ func Test_isSpecifiedRbenvRubyInstalled(t *testing.T) {
 		require.Equal(t, true, installed)
 		require.Equal(t, "2.3.5", version)
 	}
+}
+
+func Test_isSpecifiedASDFRubyInstalled_VersionIsSetByToolVersionFile(t *testing.T) {
+	// Given
+	message := `ruby            2.7.4           /Users/hisaac/.tool-versions`
+
+	// When
+	installed, version, err := isSpecifiedASDFRubyInstalled(message)
+
+	// Then
+	require.True(t, installed)
+	require.Equal(t, "2.7.4", version)
+	require.NoError(t, err)
+}
+
+func Test_isSpecifiedASDFRubyInstalled_VersionIsSetByEnvironmentVariable(t *testing.T) {
+	// Given
+	message := `ruby            2.7.4           ASDF_RUBY_VERSION environment variable`
+
+	// When
+	installed, version, err := isSpecifiedASDFRubyInstalled(message)
+
+	// Then
+	require.True(t, installed)
+	require.Equal(t, "2.7.4", version)
+	require.NoError(t, err)
+}
+
+func Test_isSpecifiedASDFRubyInstalled_VersionIsNotInstalled(t *testing.T) {
+	// Given
+	message := `Not installed. Run "asdf install ruby 2.7.4"`
+
+	// When
+	installed, version, err := isSpecifiedASDFRubyInstalled(message)
+
+	// Then
+	require.False(t, installed)
+	require.Equal(t, "2.7.4", version)
+	require.NoError(t, err)
 }
 
 func Test_gemInstallCommand(t *testing.T) {


### PR DESCRIPTION
I'm trying to get the CocoaPods step working on my computer, but I use `asdf` to manage Ruby versions.

We added support for asdf to v2 of this library, but the CocoaPods step uses v1. I attempted to update the step to just use v2, but it turned into a big ol' mess, so I thought instead I'd just backport the work we did for v2 to v1.

## Changes

Essentially matched the changes to my PR to v2 here: https://github.com/bitrise-io/go-steputils/pull/53