### PR TITLE
Expose cache hit info as output

### DIFF
--- a/cache/common.go
+++ b/cache/common.go
@@ -7,8 +7,10 @@ import (
 	"os"
 )
 
+const cacheHitEnvVar = "BITRISE_CACHE_HIT"
+
 // We need this prefix because there could be multiple restore steps in one workflow with multiple cache keys
-const cacheHitEnvVarPrefix = "BITRISE_CACHE_HIT__"
+const cacheHitUniqueEnvVarPrefix = "BITRISE_CACHE_HIT__"
 
 func checksumOfFile(path string) (string, error) {
 	hash := sha256.New()

--- a/cache/restore_test.go
+++ b/cache/restore_test.go
@@ -161,34 +161,40 @@ func Test_evaluateKeys(t *testing.T) {
 
 func Test_exposeCacheHit(t *testing.T) {
 	tests := []struct {
-		name string
+		name          string
+		evaluatedKeys []string
 		downloadResult
 		wantEnvs []string
 		wantErr  bool
 	}{
 		{
 			name:           "no cache hit",
+			evaluatedKeys:  []string{"my-cache-key"},
 			downloadResult: downloadResult{},
 			wantEnvs:       []string{},
 			wantErr:        false,
 		},
 		{
-			name: "exact cache hit",
+			name:          "exact cache hit",
+			evaluatedKeys: []string{"my-cache-key"},
 			downloadResult: downloadResult{
 				filePath:   "testdata/dummy_file.txt",
 				matchedKey: "my-cache-key",
 			},
 			wantEnvs: []string{
+				"BITRISE_CACHE_HIT=exact",
 				"BITRISE_CACHE_HIT__my-cache-key=9a30a503b2862c51c3c5acd7fbce2f1f784cf4658ccf8e87d5023a90c21c0714",
 			},
 		},
 		{
-			name: "exact cache hit",
+			name:          "partial cache hit",
+			evaluatedKeys: []string{"my-primary-cache-key", "my-cache-key"},
 			downloadResult: downloadResult{
 				filePath:   "testdata/dummy_file.txt",
 				matchedKey: "my-cache-key",
 			},
 			wantEnvs: []string{
+				"BITRISE_CACHE_HIT=partial",
 				"BITRISE_CACHE_HIT__my-cache-key=9a30a503b2862c51c3c5acd7fbce2f1f784cf4658ccf8e87d5023a90c21c0714",
 			},
 		},
@@ -201,7 +207,7 @@ func Test_exposeCacheHit(t *testing.T) {
 				logger:     log.NewLogger(),
 				cmdFactory: command.NewFactory(envRepo),
 			}
-			if err := r.exposeCacheHit(tt.downloadResult); (err != nil) != tt.wantErr {
+			if err := r.exposeCacheHit(tt.downloadResult, tt.evaluatedKeys); (err != nil) != tt.wantErr {
 				t.Fatalf("exposeCacheHit() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			assert.Equal(t, tt.wantEnvs, envRepo.List())

--- a/cache/save_skip.go
+++ b/cache/save_skip.go
@@ -52,7 +52,7 @@ func (r skipReason) description() string {
 	case reasonNewArchiveChecksumMatch:
 		return "new cache archive is the same as the restored one"
 	case reasonNewArchiveChecksumMismatch:
-		return "new cache archive doesn't match the restored one"
+		return "new cache archive contains changed files"
 	default:
 		return "unrecognized skipReason"
 	}
@@ -109,8 +109,8 @@ func (s *saver) getCacheHits() map[string]string {
 		envKey := envParts[0]
 		envValue := envParts[1]
 
-		if strings.HasPrefix(envKey, cacheHitEnvVarPrefix) {
-			cacheKey := strings.TrimPrefix(envKey, cacheHitEnvVarPrefix)
+		if strings.HasPrefix(envKey, cacheHitUniqueEnvVarPrefix) {
+			cacheKey := strings.TrimPrefix(envKey, cacheHitUniqueEnvVarPrefix)
 			cacheHits[cacheKey] = envValue
 		}
 	}


### PR DESCRIPTION
### Context

Exposing cache hit information as a public step output in order to build conditional workflows based on the cache restore result.

### Changes

- Expose `BITRISE_CACHE_HIT` output with 3 possible values: `exact`, `partial`, `false`