### PR TITLE
Remove /x/text dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/docker/go-units v0.4.0
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/text v0.3.7
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,6 @@ golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
-golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/stepconf/strings.go
+++ b/stepconf/strings.go
@@ -43,7 +43,8 @@ func toString(config interface{}) string {
 		t = t.Elem()
 	}
 
-	str := fmt.Sprint(colorstring.Bluef("%s:\n", strings.Title(t.Name())))
+	configName := strings.Title(t.Name()) //nolint:staticcheck (it's not worth pulling the heavy /x/text lib for this simple case)
+	str := fmt.Sprint(colorstring.Bluef("%s:\n", configName))
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 		var key, _ = parseTag(field.Tag.Get("env"))

--- a/stepconf/strings.go
+++ b/stepconf/strings.go
@@ -43,7 +43,8 @@ func toString(config interface{}) string {
 		t = t.Elem()
 	}
 
-	configName := strings.Title(t.Name()) //nolint:staticcheck (it's not worth pulling the heavy /x/text lib for this simple case)
+	configName := strings.Title(t.Name()) //nolint:staticcheck
+	// It's not worth pulling the heavy /x/text lib for this simple case, string.Title() can handle the struct name
 	str := fmt.Sprint(colorstring.Bluef("%s:\n", configName))
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)

--- a/stepconf/strings.go
+++ b/stepconf/strings.go
@@ -3,10 +3,9 @@ package stepconf
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/bitrise-io/go-utils/v2/log/colorstring"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 // Print the name of the struct with Title case in blue color with followed by a newline,
@@ -44,8 +43,7 @@ func toString(config interface{}) string {
 		t = t.Elem()
 	}
 
-	titleCaseName := cases.Title(language.English, cases.NoLower).String(t.Name())
-	str := fmt.Sprint(colorstring.Bluef("%s:\n", titleCaseName))
+	str := fmt.Sprint(colorstring.Bluef("%s:\n", strings.Title(t.Name())))
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 		var key, _ = parseTag(field.Tag.Get("env"))


### PR DESCRIPTION
### Context

When using this dependency in vendored projects, I noticed a sudden growth in the vendor folder size (after an upgrade from a previous `go-steputils` version).

Seems like in #61 I added the `golang.org/x/text` dependency to replace a deprecated usage of `strings.Title()`. It got deprecated in Go 1.18 because it doesn't handle complex Unicode data, but our use case only involves title-casing a Go struct's name, so I think we'll be fine with `strings.Title()`.

By getting rid of the `/x/text` dependency, a step relying on `go-steputils` will have -65K LoC in the vendor folder:

```
❯ git diff --stat
 go.mod                                                           |    3 +-
 go.sum                                                           |    4 -
 vendor/github.com/bitrise-io/go-steputils/v2/stepconf/strings.go |    5 +-
 vendor/golang.org/x/text/AUTHORS                                 |    3 -
 vendor/golang.org/x/text/CONTRIBUTORS                            |    3 -
 vendor/golang.org/x/text/LICENSE                                 |   27 -
 vendor/golang.org/x/text/PATENTS                                 |   22 -
 vendor/golang.org/x/text/cases/cases.go                          |  162 -
 vendor/golang.org/x/text/cases/context.go                        |  376 --
 vendor/golang.org/x/text/cases/fold.go                           |   34 -
 vendor/golang.org/x/text/cases/icu.go                            |   62 -
 vendor/golang.org/x/text/cases/info.go                           |   82 -
 vendor/golang.org/x/text/cases/map.go                            |  816 -----
 vendor/golang.org/x/text/cases/tables10.0.0.go                   | 2256 ------------
 vendor/golang.org/x/text/cases/tables11.0.0.go                   | 2317 ------------
 vendor/golang.org/x/text/cases/tables12.0.0.go                   | 2360 -------------
 vendor/golang.org/x/text/cases/tables13.0.0.go                   | 2400 -------------
 vendor/golang.org/x/text/cases/tables9.0.0.go                    | 2216 ------------
 vendor/golang.org/x/text/cases/trieval.go                        |  214 --
 vendor/golang.org/x/text/internal/internal.go                    |   49 -
 vendor/golang.org/x/text/internal/language/common.go             |   16 -
 vendor/golang.org/x/text/internal/language/compact.go            |   29 -
 vendor/golang.org/x/text/internal/language/compact/compact.go    |   61 -
 vendor/golang.org/x/text/internal/language/compact/language.go   |  260 --
 vendor/golang.org/x/text/internal/language/compact/parents.go    |  120 -
 vendor/golang.org/x/text/internal/language/compact/tables.go     | 1015 ------
 vendor/golang.org/x/text/internal/language/compact/tags.go       |   91 -
 vendor/golang.org/x/text/internal/language/compose.go            |  167 -
 vendor/golang.org/x/text/internal/language/coverage.go           |   28 -
 vendor/golang.org/x/text/internal/language/language.go           |  627 ----
 vendor/golang.org/x/text/internal/language/lookup.go             |  412 ---
 vendor/golang.org/x/text/internal/language/match.go              |  226 --
 vendor/golang.org/x/text/internal/language/parse.go              |  604 ----
 vendor/golang.org/x/text/internal/language/tables.go             | 3464 ------------------
 vendor/golang.org/x/text/internal/language/tags.go               |   48 -
 vendor/golang.org/x/text/internal/match.go                       |   67 -
 vendor/golang.org/x/text/internal/tag/tag.go                     |  100 -
 vendor/golang.org/x/text/language/coverage.go                    |  187 -
 vendor/golang.org/x/text/language/doc.go                         |  102 -
 vendor/golang.org/x/text/language/go1_1.go                       |   39 -
 vendor/golang.org/x/text/language/go1_2.go                       |   12 -
 vendor/golang.org/x/text/language/language.go                    |  605 ----
 vendor/golang.org/x/text/language/match.go                       |  735 ----
 vendor/golang.org/x/text/language/parse.go                       |  250 --
 vendor/golang.org/x/text/language/tables.go                      |  298 --
 vendor/golang.org/x/text/language/tags.go                        |  145 -
 vendor/golang.org/x/text/transform/transform.go                  |  709 ----
 vendor/golang.org/x/text/unicode/norm/composition.go             |  512 ---
 vendor/golang.org/x/text/unicode/norm/forminfo.go                |  278 --
 vendor/golang.org/x/text/unicode/norm/input.go                   |  109 -
 vendor/golang.org/x/text/unicode/norm/iter.go                    |  458 ---
 vendor/golang.org/x/text/unicode/norm/normalize.go               |  609 ----
 vendor/golang.org/x/text/unicode/norm/readwriter.go              |  125 -
 vendor/golang.org/x/text/unicode/norm/tables10.0.0.go            | 7658 ----------------------------------------
 vendor/golang.org/x/text/unicode/norm/tables11.0.0.go            | 7694 ----------------------------------------
 vendor/golang.org/x/text/unicode/norm/tables12.0.0.go            | 7711 ----------------------------------------
 vendor/golang.org/x/text/unicode/norm/tables13.0.0.go            | 7761 -----------------------------------------
 vendor/golang.org/x/text/unicode/norm/tables9.0.0.go             | 7638 ----------------------------------------
 vendor/golang.org/x/text/unicode/norm/transform.go               |   88 -
 vendor/golang.org/x/text/unicode/norm/trie.go                    |   54 -
 vendor/modules.txt                                               |   13 +-
 61 files changed, 5 insertions(+), 64531 deletions(-)
```

This probably translates to some compile time improvements too.

### Changes

Remove `/x/text` dependency and change its single usage in the codebase.