### PR TITLE
Print API response after cache upload

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -51,7 +51,7 @@ workflows:
                 --data "client_id=bitrise-steps" \
                 --data "client_secret=$CACHE_API_CLIENT_SECRET" \
                 --data "grant_type=urn:ietf:params:oauth:grant-type:uma-ticket" \
-                --data "claim_token=eyJhcHBfaWQiOlsiY2FjaGUtc3RlcHMtdGVzdHMiXSwgIm9yZ19pZCI6WyJ0ZXN0LW9yZy1pZCJdLCAiYWJjc19hY2Nlc3NfZ3JhbnRlZCI6WyJ0cnVlIl19" \
+                --data "claim_token=eyJhcHBfaWQiOlsiMzYxNzJhODkyMTU1OTk1MSJdLCAib3JnX2lkIjpbIjg2NGMyZmViOTE0YzI2MTUiXSwgImFiY3NfYWNjZXNzX2dyYW50ZWQiOlsidHJ1ZSJdfQ==" \
                 --data "claim_token_format=urn:ietf:params:oauth:token-type:jwt" \
                 --data "audience=bitrise-services")
 

--- a/cache/network/mocklogger_test.go
+++ b/cache/network/mocklogger_test.go
@@ -1,0 +1,63 @@
+package network
+
+import "github.com/stretchr/testify/mock"
+
+type MockLogger struct {
+	mock.Mock
+}
+
+func (ml *MockLogger) Infof(format string, v ...interface{}) {
+	ml.Called(format, v)
+}
+
+func (ml *MockLogger) Warnf(format string, v ...interface{}) {
+	ml.Called(format, v)
+}
+
+func (ml *MockLogger) Printf(format string, v ...interface{}) {
+	ml.Called(format, v)
+}
+
+func (ml *MockLogger) Donef(format string, v ...interface{}) {
+	ml.Called(format, v)
+}
+
+func (ml *MockLogger) Debugf(format string, v ...interface{}) {
+	ml.Called(format, v)
+}
+
+func (ml *MockLogger) Errorf(format string, v ...interface{}) {
+	ml.Called(format, v)
+}
+
+func (ml *MockLogger) TInfof(format string, v ...interface{}) {
+	ml.Called(format, v)
+}
+
+func (ml *MockLogger) TWarnf(format string, v ...interface{}) {
+	ml.Called(format, v)
+}
+
+func (ml *MockLogger) TPrintf(format string, v ...interface{}) {
+	ml.Called(format, v)
+}
+
+func (ml *MockLogger) TDonef(format string, v ...interface{}) {
+	ml.Called(format, v)
+}
+
+func (ml *MockLogger) TDebugf(format string, v ...interface{}) {
+	ml.Called(format, v)
+}
+
+func (ml *MockLogger) TErrorf(format string, v ...interface{}) {
+	ml.Called(format, v)
+}
+
+func (ml *MockLogger) Println() {
+	ml.Called()
+}
+
+func (ml *MockLogger) EnableDebugLog(enable bool) {
+	ml.Called(enable)
+}

--- a/cache/network/upload.go
+++ b/cache/network/upload.go
@@ -49,11 +49,13 @@ func Upload(params UploadParams, logger log.Logger) error {
 
 	logger.Debugf("")
 	logger.Debugf("Acknowledge upload")
-	err = client.acknowledgeUpload(resp.ID)
+	response, err := client.acknowledgeUpload(resp.ID)
 	if err != nil {
 		return fmt.Errorf("failed to finalize upload: %w", err)
 	}
+
 	logger.Debugf("Upload acknowledged")
+	logResponseMessage(response, logger)
 
 	return nil
 }
@@ -68,4 +70,28 @@ func validateKey(key string, logger log.Logger) (string, error) {
 		return key[:maxKeyLength], nil
 	}
 	return key, nil
+}
+
+func logResponseMessage(response acknowledgeResponse, logger log.Logger) {
+	if response.Message == "" || response.Severity == "" {
+		return
+	}
+
+	var loggerFn func(format string, v ...interface{})
+	switch response.Severity {
+	case "debug":
+		loggerFn = logger.Debugf
+	case "info":
+		loggerFn = logger.Infof
+	case "warning":
+		loggerFn = logger.Warnf
+	case "error":
+		loggerFn = logger.Errorf
+	default:
+		loggerFn = logger.Printf
+	}
+
+	loggerFn("\n")
+	loggerFn(response.Message)
+	loggerFn("\n")
 }

--- a/integration/upload_test.go
+++ b/integration/upload_test.go
@@ -38,9 +38,7 @@ func TestUpload(t *testing.T) {
 	err := network.Upload(params, logger)
 
 	// Then
-	if err != nil {
-		t.Errorf(err.Error())
-	}
+	assert.NoError(t, err)
 
 	bytes, err := ioutil.ReadFile(testFile)
 	if err != nil {


### PR DESCRIPTION
### Context

Cache API now returns an additional debug/warning message about cache quota. This change makes the cache upload print this message with the appropriate log color.

### Changes

- Update API response handling
- Print message in the API response according to the given severity
- Tests