### PR TITLE
Fix formatting of steperror when utilizing errorutil.FormattedError

### DIFF
--- a/step/steperror.go
+++ b/step/steperror.go
@@ -1,5 +1,7 @@
 package step
 
+import "errors"
+
 // Error is an error occuring top level in a step
 type Error struct {
 	StepID, Tag, ShortMsg string
@@ -33,4 +35,12 @@ func NewErrorWithRecommendations(stepID, tag string, err error, shortMsg string,
 
 func (e *Error) Error() string {
 	return e.Err.Error()
+}
+
+func (e *Error) Unwrap() error {
+	if err := errors.Unwrap(e.Err); err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
Before:
<img width="697" alt="image" src="https://user-images.githubusercontent.com/6758788/226376606-ee09d76f-01dd-4989-b651-1a1966aae4b2.png">

After:
<img width="573" alt="image" src="https://user-images.githubusercontent.com/6758788/226376334-56a1c03e-b758-46a5-bd6f-610b2b4d84cf.png">