### PR TITLE
Fix Content-Length header in cache upload request

### DIFF
--- a/cache/network/api.go
+++ b/cache/network/api.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"os"
 	"strings"
 
+	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/hashicorp/go-retryablehttp"
 )
 
@@ -45,13 +46,15 @@ type apiClient struct {
 	httpClient  *retryablehttp.Client
 	baseURL     string
 	accessToken string
+	logger      log.Logger
 }
 
-func newAPIClient(client *retryablehttp.Client, baseURL string, accessToken string) apiClient {
+func newAPIClient(client *retryablehttp.Client, baseURL string, accessToken string, logger log.Logger) apiClient {
 	return apiClient{
 		httpClient:  client,
 		baseURL:     baseURL,
 		accessToken: accessToken,
+		logger:      logger,
 	}
 }
 
@@ -77,7 +80,7 @@ func (c apiClient) prepareUpload(requestBody prepareUploadRequest) (prepareUploa
 	defer func(body io.ReadCloser) {
 		err := body.Close()
 		if err != nil {
-			log.Print(err.Error())
+			c.logger.Printf(err.Error())
 		}
 	}(resp.Body)
 
@@ -113,8 +116,14 @@ func (c apiClient) uploadArchive(archivePath, uploadMethod, uploadURL string, he
 	if err != nil {
 		return err
 	}
-	req.Header.Add("Content-Length", fmt.Sprintf("%d", fileInfo.Size()))
+	req.Header.Set("Content-Length", fmt.Sprintf("%d", fileInfo.Size()))
 	req.ContentLength = fileInfo.Size()
+
+	dump, err := httputil.DumpRequest(req.Request, false)
+	if err != nil {
+		c.logger.Warnf("error while dumping request: %s", err)
+	}
+	c.logger.Debugf("Request dump: %s", string(dump))
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -123,9 +132,15 @@ func (c apiClient) uploadArchive(archivePath, uploadMethod, uploadURL string, he
 	defer func(body io.ReadCloser) {
 		err := body.Close()
 		if err != nil {
-			log.Print(err.Error())
+			c.logger.Printf(err.Error())
 		}
 	}(resp.Body)
+
+	dump, err = httputil.DumpResponse(resp, true)
+	if err != nil {
+		c.logger.Warnf("error while dumping response: %s", err)
+	}
+	c.logger.Debugf("Response dump: %s", string(dump))
 
 	if resp.StatusCode != http.StatusOK {
 		return unwrapError(resp)
@@ -150,7 +165,7 @@ func (c apiClient) acknowledgeUpload(uploadID string) (acknowledgeResponse, erro
 	defer func(body io.ReadCloser) {
 		err := body.Close()
 		if err != nil {
-			log.Print(err.Error())
+			c.logger.Printf(err.Error())
 		}
 	}(resp.Body)
 
@@ -186,7 +201,7 @@ func (c apiClient) restore(cacheKeys []string) (restoreResponse, error) {
 	defer func(body io.ReadCloser) {
 		err := body.Close()
 		if err != nil {
-			log.Print(err.Error())
+			c.logger.Printf(err.Error())
 		}
 	}(resp.Body)
 
@@ -215,7 +230,7 @@ func (c apiClient) downloadArchive(url string) (io.ReadCloser, error) {
 		defer func(body io.ReadCloser) {
 			err := body.Close()
 			if err != nil {
-				log.Print(err.Error())
+				c.logger.Printf(err.Error())
 			}
 		}(resp.Body)
 		return nil, unwrapError(resp)

--- a/cache/network/api.go
+++ b/cache/network/api.go
@@ -108,6 +108,14 @@ func (c apiClient) uploadArchive(archivePath, uploadMethod, uploadURL string, he
 		req.Header.Set(k, v)
 	}
 
+	// Add Content-Length header manually because retryablehttp doesn't do it automatically
+	fileInfo, err := os.Stat(archivePath)
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Content-Length", fmt.Sprintf("%d", fileInfo.Size()))
+	req.ContentLength = fileInfo.Size()
+
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return err

--- a/cache/network/download.go
+++ b/cache/network/download.go
@@ -36,7 +36,7 @@ func Download(params DownloadParams, logger log.Logger) (matchedKey string, err 
 		return "", fmt.Errorf("cache key list is empty")
 	}
 
-	client := newAPIClient(retryhttp.NewClient(logger), params.APIBaseURL, params.Token)
+	client := newAPIClient(retryhttp.NewClient(logger), params.APIBaseURL, params.Token, logger)
 
 	logger.Debugf("Get download URL")
 	restoreResponse, err := client.restore(params.CacheKeys)

--- a/cache/network/upload.go
+++ b/cache/network/upload.go
@@ -25,7 +25,7 @@ func Upload(params UploadParams, logger log.Logger) error {
 		return err
 	}
 
-	client := newAPIClient(retryhttp.NewClient(logger), params.APIBaseURL, params.Token)
+	client := newAPIClient(retryhttp.NewClient(logger), params.APIBaseURL, params.Token, logger)
 
 	logger.Debugf("Get upload URL")
 	prepareUploadRequest := prepareUploadRequest{

--- a/cache/save_test.go
+++ b/cache/save_test.go
@@ -74,12 +74,12 @@ func Test_ProcessSaveConfig(t *testing.T) {
 			input: SaveCacheInput{
 				Verbose: false,
 				Key:     "cache-key",
-				Paths:   []string{"~/.prof*"},
+				Paths:   []string{"~/.ss*"},
 			},
 			want: saveCacheConfig{
 				Verbose:        false,
 				Key:            "cache-key",
-				Paths:          []string{filepath.Join(homeAbsPath, ".profile")},
+				Paths:          []string{filepath.Join(homeAbsPath, ".ssh")},
 				APIBaseURL:     "fake cache service URL",
 				APIAccessToken: "fake cache service access token",
 			},

--- a/cache/save_test.go
+++ b/cache/save_test.go
@@ -74,12 +74,12 @@ func Test_ProcessSaveConfig(t *testing.T) {
 			input: SaveCacheInput{
 				Verbose: false,
 				Key:     "cache-key",
-				Paths:   []string{"~/.bash_h*"},
+				Paths:   []string{"~/.prof*"},
 			},
 			want: saveCacheConfig{
 				Verbose:        false,
 				Key:            "cache-key",
-				Paths:          []string{filepath.Join(homeAbsPath, ".bash_history")},
+				Paths:          []string{filepath.Join(homeAbsPath, ".profile")},
 				APIBaseURL:     "fake cache service URL",
 				APIAccessToken: "fake cache service access token",
 			},


### PR DESCRIPTION
### Context

We noticed that the `Content-Length` header is missing from the upload request. This is probably a bug in the `retryablehttp` client, so this PR sets the content length manually.