### PR TITLE
Retry download url

### DIFF
--- a/cache/network/download.go
+++ b/cache/network/download.go
@@ -10,15 +10,17 @@ import (
 	"github.com/bitrise-io/go-utils/retry"
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-utils/v2/retryhttp"
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/melbahja/got"
 )
 
 // DownloadParams ...
 type DownloadParams struct {
-	APIBaseURL   string
-	Token        string
-	CacheKeys    []string
-	DownloadPath string
+	APIBaseURL     string
+	Token          string
+	CacheKeys      []string
+	DownloadPath   string
+	NumFullRetries int
 }
 
 // ErrCacheNotFound ...
@@ -27,6 +29,11 @@ var ErrCacheNotFound = errors.New("no cache archive found for the provided keys"
 // Download archive from the cache API based on the provided keys in params.
 // If there is no match for any of the keys, the error is ErrCacheNotFound.
 func Download(ctx context.Context, params DownloadParams, logger log.Logger) (string, error) {
+	retryableHTTPClient := retryhttp.NewClient(logger)
+	return downloadWithClient(ctx, retryableHTTPClient, params, logger)
+}
+
+func downloadWithClient(ctx context.Context, httpClient *retryablehttp.Client, params DownloadParams, logger log.Logger) (string, error) {
 	if params.APIBaseURL == "" {
 		return "", fmt.Errorf("API base URL is empty")
 	}
@@ -40,25 +47,24 @@ func Download(ctx context.Context, params DownloadParams, logger log.Logger) (st
 	}
 
 	matchedKey := ""
-	err := retry.Times(5).Wait(5 * time.Second).Try(func(attempt uint) error {
+	err := retry.Times(uint(params.NumFullRetries)).Wait(5 * time.Second).Try(func(attempt uint) error {
 		if attempt != 0 {
-			logger.Debugf("Archive download attempt %d", attempt+1)
+			logger.Debugf("Retrying archive download... (attempt %d)", attempt+1)
 		}
 
-		retryableHTTPClient := retryhttp.NewClient(logger)
-		client := newAPIClient(retryableHTTPClient, params.APIBaseURL, params.Token, logger)
+		client := newAPIClient(httpClient, params.APIBaseURL, params.Token, logger)
 
 		logger.Debugf("Fetching download URL...")
 		restoreResponse, err := client.restore(params.CacheKeys)
 		if err != nil {
-			logger.Debugf("Failed to get download URL: %w", err)
+			logger.Debugf("Failed to get download URL: %s", err)
 			return fmt.Errorf("failed to get download URL: %w", err)
 		}
 
 		logger.Debugf("Downloading archive...")
-		downloadErr := downloadFile(ctx, retryableHTTPClient.StandardClient(), restoreResponse.URL, params.DownloadPath, logger)
+		downloadErr := downloadFile(ctx, httpClient.StandardClient(), restoreResponse.URL, params.DownloadPath)
 		if downloadErr != nil {
-			logger.Debugf("Failed to download archive: %w", downloadErr)
+			logger.Debugf("Failed to download archive: %s", downloadErr)
 			return fmt.Errorf("failed to download archive: %w", downloadErr)
 		}
 
@@ -69,7 +75,7 @@ func Download(ctx context.Context, params DownloadParams, logger log.Logger) (st
 	return matchedKey, err
 }
 
-func downloadFile(ctx context.Context, client *http.Client, url string, dest string, logger log.Logger) error {
+func downloadFile(ctx context.Context, client *http.Client, url string, dest string) error {
 	downloader := got.New()
 	downloader.Client = client
 

--- a/cache/restore.go
+++ b/cache/restore.go
@@ -22,9 +22,10 @@ import (
 // RestoreCacheInput is the information that comes from the cache steps that call this shared implementation
 type RestoreCacheInput struct {
 	// StepId identifies the exact cache step. Used for logging events.
-	StepId  string
-	Verbose bool
-	Keys    []string
+	StepId         string
+	Verbose        bool
+	Keys           []string
+	NumFullRetries int
 }
 
 // Restorer ...
@@ -37,6 +38,7 @@ type restoreCacheConfig struct {
 	Keys           []string
 	APIBaseURL     stepconf.Secret
 	APIAccessToken stepconf.Secret
+	NumFullRetries int
 }
 
 type restorer struct {
@@ -137,6 +139,7 @@ func (r *restorer) createConfig(input RestoreCacheInput) (restoreCacheConfig, er
 		Keys:           keys,
 		APIBaseURL:     stepconf.Secret(apiBaseURL),
 		APIAccessToken: stepconf.Secret(apiAccessToken),
+		NumFullRetries: input.NumFullRetries,
 	}, nil
 }
 
@@ -171,10 +174,11 @@ func (r *restorer) download(ctx context.Context, config restoreCacheConfig) (dow
 	downloadPath := filepath.Join(dir, name)
 
 	params := network.DownloadParams{
-		APIBaseURL:   string(config.APIBaseURL),
-		Token:        string(config.APIAccessToken),
-		CacheKeys:    config.Keys,
-		DownloadPath: downloadPath,
+		APIBaseURL:     string(config.APIBaseURL),
+		Token:          string(config.APIAccessToken),
+		CacheKeys:      config.Keys,
+		DownloadPath:   downloadPath,
+		NumFullRetries: config.NumFullRetries,
 	}
 	matchedKey, err := network.Download(ctx, params, r.logger)
 	if err != nil {


### PR DESCRIPTION
Currently the download URL is valid for 1 minute. This prevents the "full retry" to work after that time.
Updated "full retry" to include fetching of the signed download URL.
The signed URL lifetime is not changed at the moment.