### PR TITLE
Fix compress command outputs

### DIFF
--- a/cache/compression/compression.go
+++ b/cache/compression/compression.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/bitrise-io/go-utils/v2/command"
@@ -212,13 +211,9 @@ func (a *Archiver) compressWithBinary(archivePath string, includePaths []string)
 
 	a.logger.Debugf("$ %s", cmd.PrintableCommandArgs())
 
-	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	_, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			return fmt.Errorf("command failed with exit status %d (%s):\n%w", exitErr.ExitCode(), cmd.PrintableCommandArgs(), errors.New(out))
-		}
-		return fmt.Errorf("executing command failed (%s): %w", cmd.PrintableCommandArgs(), err)
+		return err
 	}
 
 	return nil
@@ -310,13 +305,9 @@ func (a *Archiver) decompressWithBinary(archivePath string, destinationDirectory
 	cmd := commandFactory.Create("tar", decompressTarArgs, nil)
 	a.logger.Debugf("$ %s", cmd.PrintableCommandArgs())
 
-	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	_, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			return fmt.Errorf("command failed with exit status %d (%s):\n%w", exitErr.ExitCode(), cmd.PrintableCommandArgs(), errors.New(out))
-		}
-		return fmt.Errorf("executing command failed (%s): %w", cmd.PrintableCommandArgs(), err)
+		return err
 	}
 
 	return nil

--- a/cache/compression/compression.go
+++ b/cache/compression/compression.go
@@ -211,8 +211,9 @@ func (a *Archiver) compressWithBinary(archivePath string, includePaths []string)
 
 	a.logger.Debugf("$ %s", cmd.PrintableCommandArgs())
 
-	_, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
+		a.logger.Printf("Output: %s", out)
 		return err
 	}
 
@@ -305,8 +306,9 @@ func (a *Archiver) decompressWithBinary(archivePath string, destinationDirectory
 	cmd := commandFactory.Create("tar", decompressTarArgs, nil)
 	a.logger.Debugf("$ %s", cmd.PrintableCommandArgs())
 
-	_, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
+		a.logger.Printf("Output: %s", out)
 		return err
 	}
 


### PR DESCRIPTION
Print the default errors returned by v2 command: https://github.com/bitrise-io/go-utils/blob/9606561f924c4ea4ddc71189256a20f4499cd396/command/command.go#L168.
This solves the issue that the ExitError is not returned currently by command package (to be solved in an other PR), and reusing the default "known good" error handling.