### PR TITLE
Add more elapsed time logging to cache save step

### DIFF
--- a/cache/compression/compression_test.go
+++ b/cache/compression/compression_test.go
@@ -12,19 +12,19 @@ func TestAreAllPathsEmpty(t *testing.T) {
 	basePath := t.TempDir()
 	err := os.MkdirAll(filepath.Join(basePath, "empty_dir"), 0700)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatalf("failed to create empty directory: %s", err)
 	}
 	err = os.MkdirAll(filepath.Join(basePath, "dir_with_dir_child", "nested_empty_dir"), 0700)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatalf("failed to create directory with empty nested dir: %s", err)
 	}
 	err = os.MkdirAll(filepath.Join(basePath, "first_level", "second_level"), 0700)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatalf("failed to create directory with a second level directory: %s", err)
 	}
 	err = ioutil.WriteFile(filepath.Join(basePath, "first_level", "second_level", "nested_file.txt"), []byte("hello"), 0700)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatalf("failed to write file: %s", err)
 	}
 
 	tests := []struct {

--- a/cache/keytemplate/checksum_test.go
+++ b/cache/keytemplate/checksum_test.go
@@ -11,7 +11,7 @@ import (
 func TestChecksum(t *testing.T) {
 	testdataAbsPath, err := filepath.Abs("testdata")
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatalf("Failed to get absolute path, error: %s", err)
 	}
 
 	tests := []struct {

--- a/cache/save.go
+++ b/cache/save.go
@@ -178,12 +178,14 @@ func (s *saver) createConfig(input SaveCacheInput) (saveCacheConfig, error) {
 	s.logger.Println()
 	s.logger.Printf("Evaluating key template: %s", input.Key)
 	evaluatedKey, err := s.evaluateKey(input.Key)
+	s.logger.TDebugf("Key template evaluated")
 	if err != nil {
 		return saveCacheConfig{}, fmt.Errorf("failed to evaluate key template: %s", err)
 	}
 	s.logger.Donef("Cache key: %s", evaluatedKey)
 
 	finalPaths, err := s.evaluatePaths(input.Paths)
+	s.logger.TDebugf("Final paths evaluated")
 	if err != nil {
 		return saveCacheConfig{}, fmt.Errorf("failed to parse paths: %w", err)
 	}
@@ -196,6 +198,7 @@ func (s *saver) createConfig(input SaveCacheInput) (saveCacheConfig, error) {
 	if apiAccessToken == "" {
 		return saveCacheConfig{}, fmt.Errorf("the secret 'BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN' is not defined")
 	}
+	s.logger.TDebugf("Url and token are valid")
 
 	if input.CompressionLevel == 0 {
 		input.CompressionLevel = 3

--- a/cache/save_test.go
+++ b/cache/save_test.go
@@ -14,11 +14,11 @@ import (
 func Test_ProcessSaveConfig(t *testing.T) {
 	testdataAbsPath, err := filepath.Abs("testdata")
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatalf("Failed to get test data absolute path, error: %s", err)
 	}
 	homeAbsPath, err := os.UserHomeDir()
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatalf("Failed to get home absolute path, error: %s", err)
 	}
 
 	tests := []struct {

--- a/export/export.go
+++ b/export/export.go
@@ -165,7 +165,7 @@ func copyFile(source, destination string) error {
 	defer func(out *os.File) {
 		err := out.Close()
 		if err != nil {
-			log.Fatalf(err.Error())
+			log.Fatalf("Failed to close output file: %s", err)
 		}
 	}(out)
 


### PR DESCRIPTION
We need more information about the length of each part in this step to understand a customer issue more.
(The whole step takes ~40mins even if it decides not to upload anything).