### PR TITLE
Ignore symlinks during path evaluation

### DIFF
--- a/cache/keytemplate/checksum.go
+++ b/cache/keytemplate/checksum.go
@@ -63,7 +63,7 @@ func (m Model) evaluateGlobPatterns(paths []string) []string {
 				continue
 			}
 			m.logger.Debugf("Finding matches for %s/%s", absBase, pattern)
-			matches, err := doublestar.Glob(os.DirFS(absBase), pattern)
+			matches, err := doublestar.Glob(os.DirFS(absBase), pattern, doublestar.WithNoFollow())
 			if matches == nil {
 				m.logger.Warnf("No match for pattern: %s", path)
 				continue

--- a/cache/save.go
+++ b/cache/save.go
@@ -232,7 +232,7 @@ func (s *saver) evaluatePaths(paths []string) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		matches, err := doublestar.Glob(os.DirFS(absBase), pattern)
+		matches, err := doublestar.Glob(os.DirFS(absBase), pattern, doublestar.WithNoFollow())
 		if matches == nil {
 			s.logger.Warnf("No match for path pattern: %s", path)
 			continue

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bitrise-io/go-utils v1.0.13
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.23
 	github.com/bitrise-io/got v0.0.0-20240902113940-25f6469d1456
-	github.com/bmatcuk/doublestar/v4 v4.2.0
+	github.com/bmatcuk/doublestar/v4 v4.6.1
 	github.com/docker/go-units v0.4.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/klauspost/compress v1.17.8

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/bitrise-io/got v0.0.0-20240902113940-25f6469d1456 h1:nnr8l7tIFNx9ESyE
 github.com/bitrise-io/got v0.0.0-20240902113940-25f6469d1456/go.mod h1:uBBISwY9ylo62hC1MRHqGxH+VJGHwXR1VJ17QApnG14=
 github.com/bmatcuk/doublestar/v4 v4.2.0 h1:Qu+u9wR3Vd89LnlLMHvnZ5coJMWKQamqdz9/p5GNthA=
 github.com/bmatcuk/doublestar/v4 v4.2.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
+github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=
+github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/vendor/github.com/bmatcuk/doublestar/v4/.codecov.yml
+++ b/vendor/github.com/bmatcuk/doublestar/v4/.codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%
+    patch:
+      default:
+        target: 70%
+ignore:
+  - globoptions.go

--- a/vendor/github.com/bmatcuk/doublestar/v4/README.md
+++ b/vendor/github.com/bmatcuk/doublestar/v4/README.md
@@ -56,6 +56,16 @@ import "github.com/bmatcuk/doublestar/v4"
 
 ## Usage
 
+### ErrBadPattern
+
+```go
+doublestar.ErrBadPattern
+```
+
+Returned by various functions to report that the pattern is malformed. At the
+moment, this value is equal to `path.ErrBadPattern`, but, for portability, this
+equivalence should probably not be relied upon.
+
 ### Match
 
 ```go
@@ -67,13 +77,16 @@ Match returns true if `name` matches the file name `pattern` ([see
 and may be relative or absolute.
 
 Match requires pattern to match all of name, not just a substring. The only
-possible returned error is ErrBadPattern, when pattern is malformed.
+possible returned error is `ErrBadPattern`, when pattern is malformed.
 
 Note: this is meant as a drop-in replacement for `path.Match()` which always
 uses `'/'` as the path separator. If you want to support systems which use a
 different path separator (such as Windows), what you want is `PathMatch()`.
 Alternatively, you can run `filepath.ToSlash()` on both pattern and name and
 then use this function.
+
+Note: users should _not_ count on the returned error,
+`doublestar.ErrBadPattern`, being equal to `path.ErrBadPattern`.
 
 
 ### PathMatch
@@ -92,19 +105,74 @@ that both `pattern` and `name` are using the system's path separator. If you
 can't be sure of that, use `filepath.ToSlash()` on both `pattern` and `name`,
 and then use the `Match()` function instead.
 
+### GlobOption
+
+Options that may be passed to `Glob`, `GlobWalk`, or `FilepathGlob`. Any number
+of options may be passed to these functions, and in any order, as the last
+argument(s).
+
+```go
+WithFailOnIOErrors()
+```
+
+If passed, doublestar will abort and return IO errors when encountered. Note
+that if the glob pattern references a path that does not exist (such as
+`nonexistent/path/*`), this is _not_ considered an IO error: it is considered a
+pattern with no matches.
+
+```go
+WithFailOnPatternNotExist()
+```
+
+If passed, doublestar will abort and return `doublestar.ErrPatternNotExist` if
+the pattern references a path that does not exist before any meta characters
+such as `nonexistent/path/*`. Note that alts (ie, `{...}`) are expanded before
+this check. In other words, a pattern such as `{a,b}/*` may fail if either `a`
+or `b` do not exist but `*/{a,b}` will never fail because the star may match
+nothing.
+
+```go
+WithFilesOnly()
+```
+
+If passed, doublestar will only return "files" from `Glob`, `GlobWalk`, or
+`FilepathGlob`. In this context, "files" are anything that is not a directory
+or a symlink to a directory.
+
+Note: if combined with the WithNoFollow option, symlinks to directories _will_
+be included in the result since no attempt is made to follow the symlink.
+
+```go
+WithNoFollow()
+```
+
+If passed, doublestar will not follow symlinks while traversing the filesystem.
+However, due to io/fs's _very_ poor support for querying the filesystem about
+symlinks, there's a caveat here: if part of the pattern before any meta
+characters contains a reference to a symlink, it will be followed. For example,
+a pattern such as `path/to/symlink/*` will be followed assuming it is a valid
+symlink to a directory. However, from this same example, a pattern such as
+`path/to/**` will not traverse the `symlink`, nor would `path/*/symlink/*`
+
+Note: if combined with the WithFilesOnly option, symlinks to directories _will_
+be included in the result since no attempt is made to follow the symlink.
+
 ### Glob
 
 ```go
-func Glob(fsys fs.FS, pattern string) ([]string, error)
+func Glob(fsys fs.FS, pattern string, opts ...GlobOption) ([]string, error)
 ```
 
 Glob returns the names of all files matching pattern or nil if there is no
 matching file. The syntax of patterns is the same as in `Match()`. The pattern
 may describe hierarchical names such as `usr/*/bin/ed`.
 
-Glob ignores file system errors such as I/O errors reading directories.  The
-only possible returned error is ErrBadPattern, reporting that the pattern is
-malformed.
+Glob ignores file system errors such as I/O errors reading directories by
+default. The only possible returned error is `ErrBadPattern`, reporting that
+the pattern is malformed.
+
+To enable aborting on I/O errors, the `WithFailOnIOErrors` option can be
+passed.
 
 Note: this is meant as a drop-in replacement for `io/fs.Glob()`. Like
 `io/fs.Glob()`, this function assumes that your pattern uses `/` as the path
@@ -118,12 +186,15 @@ decision](https://github.com/golang/go/issues/44092#issuecomment-774132549),
 even if counter-intuitive. You can use [SplitPattern] to divide a pattern into
 a base path (to initialize an `FS` object) and pattern.
 
+Note: users should _not_ count on the returned error,
+`doublestar.ErrBadPattern`, being equal to `path.ErrBadPattern`.
+
 ### GlobWalk
 
 ```go
 type GlobWalkFunc func(path string, d fs.DirEntry) error
 
-func GlobWalk(fsys fs.FS, pattern string, fn GlobWalkFunc) error
+func GlobWalk(fsys fs.FS, pattern string, fn GlobWalkFunc, opts ...GlobOption) error
 ```
 
 GlobWalk calls the callback function `fn` for every file matching pattern.  The
@@ -141,8 +212,13 @@ will skip the current directory. This means that if the current path _is_ a
 directory, GlobWalk will not recurse into it. If the current path is not a
 directory, the rest of the parent directory will be skipped.
 
-GlobWalk ignores file system errors such as I/O errors reading directories.
-GlobWalk may return ErrBadPattern, reporting that the pattern is malformed.
+GlobWalk ignores file system errors such as I/O errors reading directories by
+default. GlobWalk may return `ErrBadPattern`, reporting that the pattern is
+malformed.
+
+To enable aborting on I/O errors, the `WithFailOnIOErrors` option can be
+passed.
+
 Additionally, if the callback function `fn` returns an error, GlobWalk will
 exit immediately and return that error.
 
@@ -151,19 +227,25 @@ separator even if that's not correct for your OS (like Windows). If you aren't
 sure if that's the case, you can use filepath.ToSlash() on your pattern before
 calling GlobWalk().
 
+Note: users should _not_ count on the returned error,
+`doublestar.ErrBadPattern`, being equal to `path.ErrBadPattern`.
+
 ### FilepathGlob
 
 ```go
-func FilepathGlob(pattern string) (matches []string, err error)
+func FilepathGlob(pattern string, opts ...GlobOption) (matches []string, err error)
 ```
 
 FilepathGlob returns the names of all files matching pattern or nil if there is
 no matching file. The syntax of pattern is the same as in Match(). The pattern
 may describe hierarchical names such as usr/*/bin/ed.
 
-FilepathGlob ignores file system errors such as I/O errors reading directories.
-The only possible returned error is ErrBadPattern, reporting that the pattern
-is malformed.
+FilepathGlob ignores file system errors such as I/O errors reading directories
+by default. The only possible returned error is `ErrBadPattern`, reporting that
+the pattern is malformed.
+
+To enable aborting on I/O errors, the `WithFailOnIOErrors` option can be
+passed.
 
 Note: FilepathGlob is a convenience function that is meant as a drop-in
 replacement for `path/filepath.Glob()` for users who don't need the
@@ -176,6 +258,9 @@ complication of io/fs. Basically, it:
 
 Returned paths will use the system's path separator, just like
 `filepath.Glob()`.
+
+Note: the returned error `doublestar.ErrBadPattern` is not equal to
+`filepath.ErrBadPattern`.
 
 ### SplitPattern
 
@@ -301,8 +386,6 @@ I started this project in 2014 in my spare time and have been maintaining it
 ever since. In that time, it has grown into one of the most popular globbing
 libraries in the Go ecosystem. So, if **doublestar** is a useful library in
 your project, consider [sponsoring] my work! I'd really appreciate it!
-
-[![reviewpad](../sponsors/reviewpad.png?raw=true)](https://reviewpad.com/)
 
 Thanks for sponsoring me!
 

--- a/vendor/github.com/bmatcuk/doublestar/v4/doublestar.go
+++ b/vendor/github.com/bmatcuk/doublestar/v4/doublestar.go
@@ -1,8 +1,13 @@
 package doublestar
 
 import (
+	"errors"
 	"path"
 )
 
 // ErrBadPattern indicates a pattern was malformed.
 var ErrBadPattern = path.ErrBadPattern
+
+// ErrPatternNotExist indicates that the pattern passed to Glob, GlobWalk, or
+// FilepathGlob references a path that does not exist.
+var ErrPatternNotExist = errors.New("pattern does not exist")

--- a/vendor/github.com/bmatcuk/doublestar/v4/globoptions.go
+++ b/vendor/github.com/bmatcuk/doublestar/v4/globoptions.go
@@ -1,0 +1,144 @@
+package doublestar
+
+import "strings"
+
+// glob is an internal type to store options during globbing.
+type glob struct {
+	failOnIOErrors        bool
+	failOnPatternNotExist bool
+	filesOnly             bool
+	noFollow              bool
+}
+
+// GlobOption represents a setting that can be passed to Glob, GlobWalk, and
+// FilepathGlob.
+type GlobOption func(*glob)
+
+// Construct a new glob object with the given options
+func newGlob(opts ...GlobOption) *glob {
+	g := &glob{}
+	for _, opt := range opts {
+		opt(g)
+	}
+	return g
+}
+
+// WithFailOnIOErrors is an option that can be passed to Glob, GlobWalk, or
+// FilepathGlob. If passed, doublestar will abort and return IO errors when
+// encountered. Note that if the glob pattern references a path that does not
+// exist (such as `nonexistent/path/*`), this is _not_ considered an IO error:
+// it is considered a pattern with no matches.
+//
+func WithFailOnIOErrors() GlobOption {
+	return func(g *glob) {
+		g.failOnIOErrors = true
+	}
+}
+
+// WithFailOnPatternNotExist is an option that can be passed to Glob, GlobWalk,
+// or FilepathGlob. If passed, doublestar will abort and return
+// ErrPatternNotExist if the pattern references a path that does not exist
+// before any meta charcters such as `nonexistent/path/*`. Note that alts (ie,
+// `{...}`) are expanded before this check. In other words, a pattern such as
+// `{a,b}/*` may fail if either `a` or `b` do not exist but `*/{a,b}` will
+// never fail because the star may match nothing.
+//
+func WithFailOnPatternNotExist() GlobOption {
+	return func(g *glob) {
+		g.failOnPatternNotExist = true
+	}
+}
+
+// WithFilesOnly is an option that can be passed to Glob, GlobWalk, or
+// FilepathGlob. If passed, doublestar will only return files that match the
+// pattern, not directories.
+//
+// Note: if combined with the WithNoFollow option, symlinks to directories
+// _will_ be included in the result since no attempt is made to follow the
+// symlink.
+//
+func WithFilesOnly() GlobOption {
+	return func(g *glob) {
+		g.filesOnly = true
+	}
+}
+
+// WithNoFollow is an option that can be passed to Glob, GlobWalk, or
+// FilepathGlob. If passed, doublestar will not follow symlinks while
+// traversing the filesystem. However, due to io/fs's _very_ poor support for
+// querying the filesystem about symlinks, there's a caveat here: if part of
+// the pattern before any meta characters contains a reference to a symlink, it
+// will be followed. For example, a pattern such as `path/to/symlink/*` will be
+// followed assuming it is a valid symlink to a directory. However, from this
+// same example, a pattern such as `path/to/**` will not traverse the
+// `symlink`, nor would `path/*/symlink/*`
+//
+// Note: if combined with the WithFilesOnly option, symlinks to directories
+// _will_ be included in the result since no attempt is made to follow the
+// symlink.
+//
+func WithNoFollow() GlobOption {
+	return func(g *glob) {
+		g.noFollow = true
+	}
+}
+
+// forwardErrIfFailOnIOErrors is used to wrap the return values of I/O
+// functions. When failOnIOErrors is enabled, it will return err; otherwise, it
+// always returns nil.
+//
+func (g *glob) forwardErrIfFailOnIOErrors(err error) error {
+	if g.failOnIOErrors {
+		return err
+	}
+	return nil
+}
+
+// handleErrNotExist handles fs.ErrNotExist errors. If
+// WithFailOnPatternNotExist has been enabled and canFail is true, this will
+// return ErrPatternNotExist. Otherwise, it will return nil.
+//
+func (g *glob) handlePatternNotExist(canFail bool) error {
+	if canFail && g.failOnPatternNotExist {
+		return ErrPatternNotExist
+	}
+	return nil
+}
+
+// Format options for debugging/testing purposes
+func (g *glob) GoString() string {
+	var b strings.Builder
+	b.WriteString("opts: ")
+
+	hasOpts := false
+	if g.failOnIOErrors {
+		b.WriteString("WithFailOnIOErrors")
+		hasOpts = true
+	}
+	if g.failOnPatternNotExist {
+		if hasOpts {
+			b.WriteString(", ")
+		}
+		b.WriteString("WithFailOnPatternNotExist")
+		hasOpts = true
+	}
+	if g.filesOnly {
+		if hasOpts {
+			b.WriteString(", ")
+		}
+		b.WriteString("WithFilesOnly")
+		hasOpts = true
+	}
+	if g.noFollow {
+		if hasOpts {
+			b.WriteString(", ")
+		}
+		b.WriteString("WithNoFollow")
+		hasOpts = true
+	}
+
+	if !hasOpts {
+		b.WriteString("nil")
+	}
+	return b.String()
+}

--- a/vendor/github.com/bmatcuk/doublestar/v4/match.go
+++ b/vendor/github.com/bmatcuk/doublestar/v4/match.go
@@ -46,6 +46,9 @@ import (
 // is PathMatch(). Alternatively, you can run filepath.ToSlash() on both
 // pattern and name and then use this function.
 //
+// Note: users should _not_ count on the returned error,
+// doublestar.ErrBadPattern, being equal to path.ErrBadPattern.
+//
 func Match(pattern, name string) (bool, error) {
 	return matchWithSeparator(pattern, name, '/', true)
 }
@@ -298,9 +301,14 @@ MATCH:
 }
 
 func isZeroLengthPattern(pattern string, separator rune) (ret bool, err error) {
-	// `/**` is a special case - a pattern such as `path/to/a/**` *should* match
-	// `path/to/a` because `a` might be a directory
-	if pattern == "" || pattern == "*" || pattern == "**" || pattern == string(separator)+"**" {
+	// `/**`, `**/`, and `/**/` are special cases - a pattern such as `path/to/a/**` or `path/to/a/**/`
+	// *should* match `path/to/a` because `a` might be a directory
+	if pattern == "" ||
+		pattern == "*" ||
+		pattern == "**" ||
+		pattern == string(separator)+"**" ||
+		pattern == "**"+string(separator) ||
+		pattern == string(separator)+"**"+string(separator) {
 		return true, nil
 	}
 

--- a/vendor/github.com/bmatcuk/doublestar/v4/utils.go
+++ b/vendor/github.com/bmatcuk/doublestar/v4/utils.go
@@ -1,6 +1,7 @@
 package doublestar
 
 import (
+	"errors"
 	"os"
 	"path"
 	"path/filepath"
@@ -62,25 +63,52 @@ func SplitPattern(p string) (base, pattern string) {
 // pattern may describe hierarchical names such as usr/*/bin/ed.
 //
 // FilepathGlob ignores file system errors such as I/O errors reading
-// directories.  The only possible returned error is ErrBadPattern, reporting
-// that the pattern is malformed.
+// directories by default. The only possible returned error is ErrBadPattern,
+// reporting that the pattern is malformed.
+//
+// To enable aborting on I/O errors, the WithFailOnIOErrors option can be
+// passed.
 //
 // Note: FilepathGlob is a convenience function that is meant as a drop-in
 // replacement for `path/filepath.Glob()` for users who don't need the
 // complication of io/fs. Basically, it:
-//   * Runs `filepath.Clean()` and `ToSlash()` on the pattern
-//   * Runs `SplitPattern()` to get a base path and a pattern to Glob
-//   * Creates an FS object from the base path and `Glob()s` on the pattern
-//   * Joins the base path with all of the matches from `Glob()`
+//   - Runs `filepath.Clean()` and `ToSlash()` on the pattern
+//   - Runs `SplitPattern()` to get a base path and a pattern to Glob
+//   - Creates an FS object from the base path and `Glob()s` on the pattern
+//   - Joins the base path with all of the matches from `Glob()`
 //
 // Returned paths will use the system's path separator, just like
 // `filepath.Glob()`.
-func FilepathGlob(pattern string) (matches []string, err error) {
+//
+// Note: the returned error doublestar.ErrBadPattern is not equal to
+// filepath.ErrBadPattern.
+//
+func FilepathGlob(pattern string, opts ...GlobOption) (matches []string, err error) {
 	pattern = filepath.Clean(pattern)
 	pattern = filepath.ToSlash(pattern)
 	base, f := SplitPattern(pattern)
+	if f == "" || f == "." || f == ".." {
+		// some special cases to match filepath.Glob behavior
+		if !ValidatePathPattern(pattern) {
+			return nil, ErrBadPattern
+		}
+
+		if filepath.Separator != '\\' {
+			pattern = unescapeMeta(pattern)
+		}
+
+		if _, err = os.Lstat(pattern); err != nil {
+			g := newGlob(opts...)
+			if errors.Is(err, os.ErrNotExist) {
+				return nil, g.handlePatternNotExist(true)
+			}
+			return nil, g.forwardErrIfFailOnIOErrors(err)
+		}
+		return []string{filepath.FromSlash(pattern)}, nil
+	}
+
 	fs := os.DirFS(base)
-	if matches, err = Glob(fs, f); err != nil {
+	if matches, err = Glob(fs, f, opts...); err != nil {
 		return nil, err
 	}
 	for i := range matches {

--- a/vendor/github.com/gofrs/uuid/v5/.pre-commit-config.yaml
+++ b/vendor/github.com/gofrs/uuid/v5/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+- repo: https://github.com/gitleaks/gitleaks
+  rev: v8.16.3
+  hooks:
+  - id: gitleaks
+- repo: https://github.com/golangci/golangci-lint
+  rev: v1.52.2
+  hooks:
+  - id: golangci-lint
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+  - id: end-of-file-fixer
+  - id: trailing-whitespace

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -19,7 +19,7 @@ github.com/bitrise-io/go-utils/v2/retryhttp
 # github.com/bitrise-io/got v0.0.0-20240902113940-25f6469d1456
 ## explicit; go 1.18
 github.com/bitrise-io/got
-# github.com/bmatcuk/doublestar/v4 v4.2.0
+# github.com/bmatcuk/doublestar/v4 v4.6.1
 ## explicit; go 1.16
 github.com/bmatcuk/doublestar/v4
 # github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
Updated `doublestar` so we could add the flags at all.