### PR TITLE
[STEP-2122] Adding legacy cache v2 package

### DIFF
--- a/oldcache/cache.go
+++ b/oldcache/cache.go
@@ -1,0 +1,133 @@
+package cache
+
+import (
+	"os"
+	"strings"
+
+	"github.com/bitrise-io/go-steputils/tools"
+)
+
+// CacheIncludePathsEnvKey ...
+const CacheIncludePathsEnvKey = "BITRISE_CACHE_INCLUDE_PATHS"
+
+// CacheExcludePathsEnvKey ...
+const CacheExcludePathsEnvKey = "BITRISE_CACHE_EXCLUDE_PATHS"
+
+// VariableSetter ...
+type VariableSetter interface {
+	Set(key, value string) error
+}
+
+// OSVariableSetter ...
+type OSVariableSetter struct{}
+
+// NewOSVariableSetter ...
+func NewOSVariableSetter() VariableSetter {
+	return OSVariableSetter{}
+}
+
+// Set ...
+func (e OSVariableSetter) Set(key, value string) error {
+	return os.Setenv(key, value)
+}
+
+// EnvmanVariableSetter ...
+type EnvmanVariableSetter struct {
+}
+
+// NewEnvmanVariableSetter ...
+func NewEnvmanVariableSetter() VariableSetter {
+	return EnvmanVariableSetter{}
+}
+
+// Set ...
+func (e EnvmanVariableSetter) Set(key, value string) error {
+	return tools.ExportEnvironmentWithEnvman(key, value)
+}
+
+// VariableGetter ...
+type VariableGetter interface {
+	Get(key string) (string, error)
+}
+
+// OSVariableGetter ...
+type OSVariableGetter struct{}
+
+// NewOSVariableGetter ...
+func NewOSVariableGetter() VariableGetter {
+	return OSVariableGetter{}
+}
+
+// Get ...
+func (e OSVariableGetter) Get(key string) (string, error) {
+	return os.Getenv(key), nil
+}
+
+// Cache ...
+type Cache struct {
+	variableGetter  VariableGetter
+	variableSetters []VariableSetter
+
+	include []string
+	exclude []string
+}
+
+// Config ...
+type Config struct {
+	VariableGetter  VariableGetter
+	VariableSetters []VariableSetter
+}
+
+// NewCache ...
+func (c Config) NewCache() Cache {
+	return Cache{variableGetter: c.VariableGetter, variableSetters: c.VariableSetters}
+}
+
+// New ...
+func New() Cache {
+	defaultConfig := Config{NewOSVariableGetter(), []VariableSetter{NewOSVariableSetter(), NewEnvmanVariableSetter()}}
+	return defaultConfig.NewCache()
+}
+
+// IncludePath ...
+func (cache *Cache) IncludePath(item ...string) {
+	cache.include = append(cache.include, item...)
+}
+
+// ExcludePath ...
+func (cache *Cache) ExcludePath(item ...string) {
+	cache.exclude = append(cache.exclude, item...)
+}
+
+// Commit ...
+func (cache *Cache) Commit() error {
+	commitCachePath := func(key string, values []string) error {
+		content, err := cache.variableGetter.Get(key)
+		if err != nil {
+			return err
+		}
+
+		if content != "" {
+			content += "\n"
+		}
+
+		content += strings.Join(values, "\n")
+		content += "\n"
+
+		for _, setter := range cache.variableSetters {
+			if err := setter.Set(key, content); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if err := commitCachePath(CacheIncludePathsEnvKey, cache.include); err != nil {
+		return err
+	}
+
+	if err := commitCachePath(CacheExcludePathsEnvKey, cache.exclude); err != nil {
+		return err
+	}
+	return nil
+}

--- a/oldcache/cache.go
+++ b/oldcache/cache.go
@@ -1,10 +1,12 @@
-package cache
+package oldcache
 
 import (
 	"os"
 	"strings"
 
-	"github.com/bitrise-io/go-steputils/tools"
+	"github.com/bitrise-io/go-steputils/v2/export"
+	"github.com/bitrise-io/go-utils/v2/command"
+	"github.com/bitrise-io/go-utils/v2/env"
 )
 
 // CacheIncludePathsEnvKey ...
@@ -42,7 +44,8 @@ func NewEnvmanVariableSetter() VariableSetter {
 
 // Set ...
 func (e EnvmanVariableSetter) Set(key, value string) error {
-	return tools.ExportEnvironmentWithEnvman(key, value)
+	exporter := export.NewExporter(command.NewFactory(env.NewRepository()))
+	return exporter.ExportOutput(key, value)
 }
 
 // VariableGetter ...

--- a/oldcache/cache_test.go
+++ b/oldcache/cache_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	cache "github.com/bitrise-io/go-steputils/v2/oldcache"
-	"github.com/bitrise-io/go-steputils/v2/stepenv"
 	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/env"
 	"github.com/bitrise-io/go-utils/v2/fileutil"
@@ -75,7 +74,6 @@ const testThirdCommitIgnoreEnvVarContent = `/*.log
 func TestCacheFunctions(t *testing.T) {
 	filemanager := fileutil.NewFileManager()
 	pathmodifier := pathutil.NewPathModifier()
-	cacheEnvRepository := stepenv.NewRepository(env.NewRepository())
 
 	t.Log("Init envman")
 	{
@@ -102,7 +100,7 @@ func TestCacheFunctions(t *testing.T) {
 
 	t.Log("Test - cache")
 	{
-		c := cache.New(cacheEnvRepository)
+		c := cache.NewDefault()
 		c.IncludePath("/tmp/mypath -> /tmp/mypath/cachefile")
 		c.IncludePath("/tmp/otherpath")
 		c.IncludePath("/tmp/anotherpath")
@@ -122,12 +120,12 @@ func TestCacheFunctions(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, testIgnoreEnvVarContent, content)
 
-		c = cache.New(cacheEnvRepository)
+		c = cache.NewDefault()
 		c.ExcludePath("/*.lock")
 		err = c.Commit()
 		require.NoError(t, err)
 
-		c = cache.New(cacheEnvRepository)
+		c = cache.NewDefault()
 		c.ExcludePath("/*.lock")
 		err = c.Commit()
 		require.NoError(t, err)

--- a/oldcache/cache_test.go
+++ b/oldcache/cache_test.go
@@ -1,0 +1,137 @@
+package cache_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bitrise-io/go-steputils/cache"
+	"github.com/bitrise-io/go-utils/command"
+	"github.com/bitrise-io/go-utils/fileutil"
+	"github.com/bitrise-io/go-utils/pathutil"
+	"github.com/stretchr/testify/require"
+)
+
+// MockGetterSetter ...
+type MockGetterSetter struct {
+	values map[string]string
+}
+
+// NewMockGetterSetter ...
+func NewMockGetterSetter() MockGetterSetter {
+	return MockGetterSetter{values: map[string]string{}}
+}
+
+// Get ...
+func (g MockGetterSetter) Get(key string) (string, error) {
+	return g.values[key], nil
+}
+
+// Set ...
+func (g MockGetterSetter) Set(key, value string) error {
+	g.values[key] = value
+	return nil
+}
+
+const testEnvVarContent = `/tmp/mypath -> /tmp/mypath/cachefile
+/tmp/otherpath
+/tmp/anotherpath
+/tmp/othercache
+/somewhere/else
+`
+
+const testIgnoreEnvVarContent = `/*.log
+/*.bin
+/*.lock
+`
+
+const testThirdCommitIgnoreEnvVarContent = `/*.log
+/*.bin
+/*.lock
+
+/*.lock
+
+/*.lock
+`
+
+func TestCacheFunctions(t *testing.T) {
+
+	t.Log("Init envman")
+	{
+		// envman requires an envstore path to use, or looks for default envstore path: ./.envstore.yml
+		workDir, err := pathutil.CurrentWorkingDirectoryAbsolutePath()
+		require.NoError(t, err)
+		defaultEnvstorePth := filepath.Join(workDir, ".envstore.yml")
+		require.NoError(t, fileutil.WriteStringToFile(defaultEnvstorePth, ""))
+		defer func() {
+			require.NoError(t, os.Remove(defaultEnvstorePth))
+		}()
+		//
+
+		{
+			// envstore should be clear
+			cmd := command.New("envman", "clear")
+			out, err := cmd.RunAndReturnTrimmedCombinedOutput()
+			require.NoError(t, err, out)
+			cmd = command.New("envman", "print")
+			out, err = cmd.RunAndReturnTrimmedCombinedOutput()
+			require.NoError(t, err, out)
+			require.Equal(t, "", out)
+		}
+	}
+
+	t.Log("Test - cache")
+	{
+		c := cache.New()
+		c.IncludePath("/tmp/mypath -> /tmp/mypath/cachefile")
+		c.IncludePath("/tmp/otherpath")
+		c.IncludePath("/tmp/anotherpath")
+		c.IncludePath("/tmp/othercache")
+		c.IncludePath("/somewhere/else")
+		c.ExcludePath("/*.log")
+		c.ExcludePath("/*.bin")
+		c.ExcludePath("/*.lock")
+		err := c.Commit()
+		require.NoError(t, err)
+
+		content, err := getEnvironmentValueWithEnvman(cache.CacheIncludePathsEnvKey)
+		require.NoError(t, err)
+		require.Equal(t, testEnvVarContent, content)
+
+		content, err = getEnvironmentValueWithEnvman(cache.CacheExcludePathsEnvKey)
+		require.NoError(t, err)
+		require.Equal(t, testIgnoreEnvVarContent, content)
+
+		c = cache.New()
+		c.ExcludePath("/*.lock")
+		err = c.Commit()
+		require.NoError(t, err)
+
+		c = cache.New()
+		c.ExcludePath("/*.lock")
+		err = c.Commit()
+		require.NoError(t, err)
+
+		content, err = getEnvironmentValueWithEnvman(cache.CacheExcludePathsEnvKey)
+		require.NoError(t, err)
+		require.Equal(t, testThirdCommitIgnoreEnvVarContent, content)
+	}
+}
+
+func getEnvironmentValueWithEnvman(key string) (string, error) {
+	cmd := command.New("envman", "print", "--format", "json")
+	output, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%s\n%s", output, err)
+	}
+
+	var data map[string]string
+	err = json.Unmarshal([]byte(output), &data)
+	if err != nil {
+		return "", fmt.Errorf("%s\n%s", output, err)
+	}
+
+	return data[key], nil
+}

--- a/oldcache/example_test.go
+++ b/oldcache/example_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	cache "github.com/bitrise-io/go-steputils/v2/oldcache"
+	"github.com/bitrise-io/go-utils/v2/env"
 )
 
 // Create ItemCollectors for listing Bitrise cache include and exclude patterns.
@@ -17,8 +18,7 @@ func (c SampleItemCollector) Collect(dir string, cacheLevel cache.Level) ([]stri
 func Example() {
 	// Create a cache, usually using cache.New()
 	getterSetter := NewMockGetterSetter()
-	testConfig := cache.Config{getterSetter, []cache.VariableSetter{getterSetter}}
-	c := testConfig.NewCache()
+	c := cache.New(getterSetter)
 
 	for _, collector := range []cache.ItemCollector{SampleItemCollector{}} {
 		// Run some Cache ItemCollectors
@@ -42,16 +42,10 @@ func Example() {
 	// exclude_me.txt
 }
 
-func printIncludeAndExcludeEnvs(getterSetter MockGetterSetter) {
-	includePaths, err := getterSetter.Get(cache.CacheIncludePathsEnvKey)
-	if err != nil {
-		panic(err)
-	}
+func printIncludeAndExcludeEnvs(getterSetter env.Repository) {
+	includePaths := getterSetter.Get(cache.CacheIncludePathsEnvKey)
 	fmt.Println(includePaths)
 
-	excludePaths, err := getterSetter.Get(cache.CacheExcludePathsEnvKey)
-	if err != nil {
-		panic(err)
-	}
+	excludePaths := getterSetter.Get(cache.CacheExcludePathsEnvKey)
 	fmt.Println(excludePaths)
 }

--- a/oldcache/example_test.go
+++ b/oldcache/example_test.go
@@ -1,9 +1,9 @@
-package cache_test
+package oldcache_test
 
 import (
 	"fmt"
 
-	"github.com/bitrise-io/go-steputils/cache"
+	cache "github.com/bitrise-io/go-steputils/v2/oldcache"
 )
 
 // Create ItemCollectors for listing Bitrise cache include and exclude patterns.

--- a/oldcache/example_test.go
+++ b/oldcache/example_test.go
@@ -1,0 +1,57 @@
+package cache_test
+
+import (
+	"fmt"
+
+	"github.com/bitrise-io/go-steputils/cache"
+)
+
+// Create ItemCollectors for listing Bitrise cache include and exclude patterns.
+type SampleItemCollector struct{}
+
+// List of include and exclude patterns are collected in a given directory, cacheLevel describes what files should be included in the cache.
+func (c SampleItemCollector) Collect(dir string, cacheLevel cache.Level) ([]string, []string, error) {
+	return []string{"include_me.md"}, []string{"exclude_me.txt"}, nil
+}
+
+func Example() {
+	// Create a cache, usually using cache.New()
+	getterSetter := NewMockGetterSetter()
+	testConfig := cache.Config{getterSetter, []cache.VariableSetter{getterSetter}}
+	c := testConfig.NewCache()
+
+	for _, collector := range []cache.ItemCollector{SampleItemCollector{}} {
+		// Run some Cache ItemCollectors
+		in, ex, err := collector.Collect("", cache.LevelDeps)
+		if err != nil {
+			panic(err)
+		}
+
+		// Store the include and exclude patterns in the cache
+		c.IncludePath(in...)
+		c.ExcludePath(ex...)
+	}
+	// Commit the cache changes
+	if err := c.Commit(); err != nil {
+		panic(err)
+	}
+
+	printIncludeAndExcludeEnvs(getterSetter)
+	// Output: include_me.md
+	//
+	// exclude_me.txt
+}
+
+func printIncludeAndExcludeEnvs(getterSetter MockGetterSetter) {
+	includePaths, err := getterSetter.Get(cache.CacheIncludePathsEnvKey)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(includePaths)
+
+	excludePaths, err := getterSetter.Get(cache.CacheExcludePathsEnvKey)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(excludePaths)
+}

--- a/oldcache/itemcollector.go
+++ b/oldcache/itemcollector.go
@@ -1,0 +1,19 @@
+package cache
+
+// Level defines the extent to which caching should be used.
+// - LevelNone: no caching
+// - LevelDeps: only dependencies will be cached
+// - LevelAll: dependencies and build files will be cache
+type Level string
+
+// Cache level
+const (
+	LevelNone = Level("none")
+	LevelDeps = Level("only_deps")
+	LevelAll  = Level("all")
+)
+
+// ItemCollector ...
+type ItemCollector interface {
+	Collect(dir string, cacheLevel Level) ([]string, []string, error)
+}

--- a/oldcache/itemcollector.go
+++ b/oldcache/itemcollector.go
@@ -1,4 +1,4 @@
-package cache
+package oldcache
 
 // Level defines the extent to which caching should be used.
 // - LevelNone: no caching


### PR DESCRIPTION
Moved [v1/cache package](https://github.com/bitrise-io/go-steputils/tree/75667a9684f92e1b2a483575504ca7a497b6a998/cache) to v2 and removed v1 references.

- Renamed pacakge to _oldcache_ to differentiate with existing _cache_ package.
- using stepenv.Repository instead of the custom OSEnvironmentSetter / Getter used.

Needed to remove [v1 reference in go-xcode](https://github.com/bitrise-io/go-xcode/blob/ccfa0a02cde65db0b50308c812a34f1c95f513d5/xcodecache/swiftpm_cache.go#L9), and possibly other usages; as a stopgap until we completely remove legacy usages.