### PR TITLE
Add option to overwrite files on fm.Copy* actions

### DIFF
--- a/cache/restore.go
+++ b/cache/restore.go
@@ -97,7 +97,7 @@ func (r *restorer) Restore(input RestoreCacheInput) error {
 		if errors.Is(err, network.ErrCacheNotFound) {
 			r.logger.Donef("No cache entry found for the provided key")
 			tracker.logRestoreResult(false, "", config.Keys)
-			exporter := export.NewExporter(r.cmdFactory)
+			exporter := export.NewExporter(r.cmdFactory, export.NewFileManager())
 			return exporter.ExportOutput(cacheHitEnvVar, "false")
 		}
 		return fmt.Errorf("download failed: %w", err)
@@ -230,7 +230,7 @@ func (r *restorer) exposeCacheHit(result downloadResult, evaluatedKeys []string)
 		return nil
 	}
 
-	exporter := export.NewExporter(r.cmdFactory)
+	exporter := export.NewExporter(r.cmdFactory, export.NewFileManager())
 	var cacheHitValue string
 	if result.matchedKey == evaluatedKeys[0] {
 		cacheHitValue = "exact"

--- a/export/export.go
+++ b/export/export.go
@@ -29,6 +29,11 @@ func NewExporter(cmdFactory command.Factory) Exporter {
 	}
 }
 
+// NewExporterWithFileManager creates an Exporter with a custom FileManager, useful for testing.
+func NewExporterWithFileManager(cmdFactory command.Factory, fm FileManager) Exporter {
+	return Exporter{cmdFactory: cmdFactory, fileManager: fm}
+}
+
 // ExportOutput is used for exposing values for other steps.
 // Regular env vars are isolated between steps, so instead of calling `os.Setenv()`, use this to explicitly expose
 // a value for subsequent steps.
@@ -54,7 +59,7 @@ func (e *Exporter) ExportSecretOutput(key, value string) error {
 
 // ExportOutputFile is a convenience method for copying sourcePath to destinationPath and then exporting the
 // absolute destination path with ExportOutput()
-func (e *Exporter) ExportOutputFile(key, sourcePath, destinationPath string) error {
+func (e *Exporter) ExportOutputFile(key, sourcePath, destinationPath string, opts *CopyOptions) error {
 	pathModifier := pathutil.NewPathModifier()
 	absSourcePath, err := pathModifier.AbsPath(sourcePath)
 	if err != nil {
@@ -66,7 +71,7 @@ func (e *Exporter) ExportOutputFile(key, sourcePath, destinationPath string) err
 	}
 
 	if absSourcePath != absDestinationPath {
-		if err = e.fileManager.CopyFile(absSourcePath, absDestinationPath); err != nil {
+		if err = e.fileManager.CopyFile(absSourcePath, absDestinationPath, opts); err != nil {
 			return err
 		}
 	}
@@ -76,7 +81,7 @@ func (e *Exporter) ExportOutputFile(key, sourcePath, destinationPath string) err
 
 // ExportOutputFilesZip is a convenience method for creating a ZIP archive from sourcePaths at zipPath and then
 // exporting the absolute path of the ZIP with ExportOutput()
-func (e *Exporter) ExportOutputFilesZip(key string, sourcePaths []string, zipPath string) error {
+func (e *Exporter) ExportOutputFilesZip(key string, sourcePaths []string, zipPath string, opts *CopyOptions) error {
 	tempZipPath, err := zipFilePath()
 	if err != nil {
 		return err
@@ -104,13 +109,13 @@ func (e *Exporter) ExportOutputFilesZip(key string, sourcePaths []string, zipPat
 		return err
 	}
 
-	return e.ExportOutputFile(key, tempZipPath, zipPath)
+	return e.ExportOutputFile(key, tempZipPath, zipPath, opts)
 }
 
 // ExportOutputDir is a convenience method for copying sourceDir to destinationDir and then exporting the
 // absolute destination dir with ExportOutput()
 // Note: symlinks are preserved during the copy operation
-func (e *Exporter) ExportOutputDir(envKey, srcDir, dstDir string) error {
+func (e *Exporter) ExportOutputDir(envKey, srcDir, dstDir string, opts *CopyOptions) error {
 	srcDir, err := filepath.Abs(srcDir)
 	if err != nil {
 		return err
@@ -132,7 +137,7 @@ func (e *Exporter) ExportOutputDir(envKey, srcDir, dstDir string) error {
 		return e.ExportOutput(envKey, dstDir)
 	}
 
-	if err := e.fileManager.CopyDir(srcDir, dstDir); err != nil {
+	if err := e.fileManager.CopyDir(srcDir, dstDir, opts); err != nil {
 		return err
 	}
 
@@ -141,18 +146,18 @@ func (e *Exporter) ExportOutputDir(envKey, srcDir, dstDir string) error {
 
 // ExportStringToFileOutput is a convenience method for writing content to dst and then exporting the
 // absolute dst path with ExportOutputFile()
-func (e *Exporter) ExportStringToFileOutput(envKey, content, dst string) error {
+func (e *Exporter) ExportStringToFileOutput(envKey, content, dst string, opts *CopyOptions) error {
 	if err := e.fileManager.WriteBytes(dst, []byte(content)); err != nil {
 		return err
 	}
 
-	return e.ExportOutputFile(envKey, dst, dst)
+	return e.ExportOutputFile(envKey, dst, dst, opts)
 }
 
 // ExportStringToFileOutputAndReturnLastNLines is similar to ExportStringToFileOutput but it also returns the
 // last N lines of the content.
-func (e *Exporter) ExportStringToFileOutputAndReturnLastNLines(envKey, content, dst string, lines int) (string, error) {
-	if err := e.ExportStringToFileOutput(envKey, content, dst); err != nil {
+func (e *Exporter) ExportStringToFileOutputAndReturnLastNLines(envKey, content, dst string, lines int, opts *CopyOptions) (string, error) {
+	if err := e.ExportStringToFileOutput(envKey, content, dst, opts); err != nil {
 		return "", err
 	}
 

--- a/export/export.go
+++ b/export/export.go
@@ -22,16 +22,11 @@ type Exporter struct {
 }
 
 // NewExporter ...
-func NewExporter(cmdFactory command.Factory) Exporter {
+func NewExporter(cmdFactory command.Factory, fm FileManager) Exporter {
 	return Exporter{
 		cmdFactory:  cmdFactory,
-		fileManager: NewFileManager(),
+		fileManager: fm,
 	}
-}
-
-// NewExporterWithFileManager creates an Exporter with a custom FileManager, useful for testing.
-func NewExporterWithFileManager(cmdFactory command.Factory, fm FileManager) Exporter {
-	return Exporter{cmdFactory: cmdFactory, fileManager: fm}
 }
 
 // ExportOutput is used for exposing values for other steps.

--- a/export/export.go
+++ b/export/export.go
@@ -53,8 +53,12 @@ func (e *Exporter) ExportSecretOutput(key, value string) error {
 }
 
 // ExportOutputFile is a convenience method for copying sourcePath to destinationPath and then exporting the
-// absolute destination path with ExportOutput()
-func (e *Exporter) ExportOutputFile(key, sourcePath, destinationPath string, opts *CopyOptions) error {
+// absolute destination path with ExportOutput().
+//
+// Attention:
+// This method will overwrite the destinationPath if existing prior to calling this; this is intentional.
+// No errors or warnings will be returned for this.
+func (e *Exporter) ExportOutputFile(key, sourcePath, destinationPath string) error {
 	pathModifier := pathutil.NewPathModifier()
 	absSourcePath, err := pathModifier.AbsPath(sourcePath)
 	if err != nil {
@@ -66,7 +70,7 @@ func (e *Exporter) ExportOutputFile(key, sourcePath, destinationPath string, opt
 	}
 
 	if absSourcePath != absDestinationPath {
-		if err = e.fileManager.CopyFile(absSourcePath, absDestinationPath, opts); err != nil {
+		if err = e.fileManager.CopyFile(absSourcePath, absDestinationPath, &CopyOptions{Overwrite: true}); err != nil {
 			return err
 		}
 	}
@@ -76,7 +80,11 @@ func (e *Exporter) ExportOutputFile(key, sourcePath, destinationPath string, opt
 
 // ExportOutputFilesZip is a convenience method for creating a ZIP archive from sourcePaths at zipPath and then
 // exporting the absolute path of the ZIP with ExportOutput()
-func (e *Exporter) ExportOutputFilesZip(key string, sourcePaths []string, zipPath string, opts *CopyOptions) error {
+//
+// Attention:
+// This method will overwrite the zipPath if existing prior to calling this; this is intentional.
+// No errors or warnings will be returned for this.
+func (e *Exporter) ExportOutputFilesZip(key string, sourcePaths []string, zipPath string) error {
 	tempZipPath, err := zipFilePath()
 	if err != nil {
 		return err
@@ -104,13 +112,17 @@ func (e *Exporter) ExportOutputFilesZip(key string, sourcePaths []string, zipPat
 		return err
 	}
 
-	return e.ExportOutputFile(key, tempZipPath, zipPath, opts)
+	return e.ExportOutputFile(key, tempZipPath, zipPath)
 }
 
 // ExportOutputDir is a convenience method for copying sourceDir to destinationDir and then exporting the
 // absolute destination dir with ExportOutput()
 // Note: symlinks are preserved during the copy operation
-func (e *Exporter) ExportOutputDir(envKey, srcDir, dstDir string, opts *CopyOptions) error {
+//
+// Attention:
+// This method will overwrite the dstDir if existing prior to calling this; this is intentional.
+// No errors or warnings will be returned for this.
+func (e *Exporter) ExportOutputDir(envKey, srcDir, dstDir string) error {
 	srcDir, err := filepath.Abs(srcDir)
 	if err != nil {
 		return err
@@ -132,7 +144,7 @@ func (e *Exporter) ExportOutputDir(envKey, srcDir, dstDir string, opts *CopyOpti
 		return e.ExportOutput(envKey, dstDir)
 	}
 
-	if err := e.fileManager.CopyDir(srcDir, dstDir, opts); err != nil {
+	if err := e.fileManager.CopyDir(srcDir, dstDir, &CopyOptions{Overwrite: true}); err != nil {
 		return err
 	}
 
@@ -141,18 +153,26 @@ func (e *Exporter) ExportOutputDir(envKey, srcDir, dstDir string, opts *CopyOpti
 
 // ExportStringToFileOutput is a convenience method for writing content to dst and then exporting the
 // absolute dst path with ExportOutputFile()
-func (e *Exporter) ExportStringToFileOutput(envKey, content, dst string, opts *CopyOptions) error {
+//
+// Attention:
+// This method will overwrite the dst if existing prior to calling this; this is intentional.
+// No errors or warnings will be returned for this.
+func (e *Exporter) ExportStringToFileOutput(envKey, content, dst string) error {
 	if err := e.fileManager.WriteBytes(dst, []byte(content)); err != nil {
 		return err
 	}
 
-	return e.ExportOutputFile(envKey, dst, dst, opts)
+	return e.ExportOutputFile(envKey, dst, dst)
 }
 
 // ExportStringToFileOutputAndReturnLastNLines is similar to ExportStringToFileOutput but it also returns the
 // last N lines of the content.
-func (e *Exporter) ExportStringToFileOutputAndReturnLastNLines(envKey, content, dst string, lines int, opts *CopyOptions) (string, error) {
-	if err := e.ExportStringToFileOutput(envKey, content, dst, opts); err != nil {
+//
+// Attention:
+// This method will overwrite the dst if existing prior to calling this; this is intentional.
+// No errors or warnings will be returned for this.
+func (e *Exporter) ExportStringToFileOutputAndReturnLastNLines(envKey, content, dst string, lines int) (string, error) {
+	if err := e.ExportStringToFileOutput(envKey, content, dst); err != nil {
 		return "", err
 	}
 

--- a/export/export_test.go
+++ b/export/export_test.go
@@ -46,7 +46,7 @@ func TestExportOutputFile(t *testing.T) {
 	require.NoError(t, os.WriteFile(sourcePath, []byte("hello"), 0700))
 
 	e := export.NewExporter(command.NewFactory(env.NewRepository()), export.NewFileManager())
-	require.NoError(t, e.ExportOutputFile("my_key", sourcePath, destinationPath, nil))
+	require.NoError(t, e.ExportOutputFile("my_key", sourcePath, destinationPath))
 
 	export.RequireEnvmanContainsValueForKey(t, "my_key", destinationPath, false, envmanStorePath)
 }
@@ -62,7 +62,7 @@ func TestExportOutputFile_GivenCopyFails_WillFail(t *testing.T) {
 	srcDir := export.CreateSrcDirWithFiles(t, tmpDir, []string{"file1", "file2", "file3"})
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 
-	require.ErrorContains(t, sut.ExportOutputFile("my_key", srcDir, dstDir, nil), "test")
+	require.ErrorContains(t, sut.ExportOutputFile("my_key", srcDir, dstDir), "test")
 }
 
 func TestExportOutputFile_GivenSameSrcAndDst_SkipsCopy(t *testing.T) {
@@ -74,7 +74,7 @@ func TestExportOutputFile_GivenSameSrcAndDst_SkipsCopy(t *testing.T) {
 
 	srcDir := export.CreateSrcDirWithFiles(t, tmpDir, []string{"file1", "file2", "file3"})
 
-	require.NoError(t, sut.ExportOutputFile("my_key", srcDir, srcDir, nil))
+	require.NoError(t, sut.ExportOutputFile("my_key", srcDir, srcDir))
 	export.RequireEnvmanContainsValueForKey(t, "my_key", srcDir, false, envmanStorePath)
 }
 
@@ -93,7 +93,7 @@ func TestZipDirectoriesAndExportOutput(t *testing.T) {
 
 	key := "EXPORTED_ZIP_PATH"
 	e := export.NewExporter(command.NewFactory(env.NewRepository()), export.NewFileManager())
-	require.NoError(t, e.ExportOutputFilesZip(key, []string{sourceA, sourceB}, destinationZip, nil))
+	require.NoError(t, e.ExportOutputFilesZip(key, []string{sourceA, sourceB}, destinationZip))
 
 	// destination should exist
 	exist, err := pathutil.NewPathChecker().IsPathExists(destinationZip)
@@ -124,7 +124,7 @@ func TestZipFilesAndExportOutput(t *testing.T) {
 
 	key := "EXPORTED_ZIP_PATH"
 	e := export.NewExporter(command.NewFactory(env.NewRepository()), export.NewFileManager())
-	require.NoError(t, e.ExportOutputFilesZip(key, sourceFilePaths, destinationZip, nil))
+	require.NoError(t, e.ExportOutputFilesZip(key, sourceFilePaths, destinationZip))
 
 	// destination should exist
 	exist, err := pathutil.NewPathChecker().IsPathExists(destinationZip)
@@ -159,7 +159,7 @@ func TestZipMixedFilesAndFoldersAndExportOutput(t *testing.T) {
 	destinationZip := filepath.Join(tmpDir, "destination.zip")
 
 	e := export.NewExporter(command.NewFactory(env.NewRepository()), export.NewFileManager())
-	require.Error(t, e.ExportOutputFilesZip("EXPORTED_ZIP_PATH", sourceFilePaths, destinationZip, nil))
+	require.Error(t, e.ExportOutputFilesZip("EXPORTED_ZIP_PATH", sourceFilePaths, destinationZip))
 }
 
 func TestExportOutputDirE2E(t *testing.T) {
@@ -176,8 +176,8 @@ func TestExportOutputDirE2E(t *testing.T) {
 
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 
-	sut := export.NewExporter((command.NewFactory(env.NewRepository())), export.NewFileManager())
-	assert.NoError(t, sut.ExportOutputDir("ENV_KEY", srcDir, dstDir, nil))
+	sut := export.NewExporter(command.NewFactory(env.NewRepository()), export.NewFileManager())
+	assert.NoError(t, sut.ExportOutputDir("ENV_KEY", srcDir, dstDir))
 	export.RequireEnvmanContainsValueForKey(t, "ENV_KEY", dstDir, false, envmanStorePath)
 
 	assert.NoError(t,
@@ -210,8 +210,8 @@ func TestExportOutputDir_GivenSrcIsFile_Fails(t *testing.T) {
 
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 
-	e := export.NewExporter((command.NewFactory(env.NewRepository())), export.NewFileManager())
-	assert.Error(t, e.ExportOutputDir("ENV_KEY", srcDir+"/file1", dstDir, nil))
+	e := export.NewExporter(command.NewFactory(env.NewRepository()), export.NewFileManager())
+	assert.Error(t, e.ExportOutputDir("ENV_KEY", srcDir+"/file1", dstDir))
 }
 
 func TestExportOutputDir_GivenMissingSrc_Fails(t *testing.T) {
@@ -221,16 +221,16 @@ func TestExportOutputDir_GivenMissingSrc_Fails(t *testing.T) {
 
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 
-	e := export.NewExporter((command.NewFactory(env.NewRepository())), export.NewFileManager())
-	assert.Error(t, e.ExportOutputDir("ENV_KEY", dstDir+"/file1", dstDir, nil))
+	e := export.NewExporter(command.NewFactory(env.NewRepository()), export.NewFileManager())
+	assert.Error(t, e.ExportOutputDir("ENV_KEY", dstDir+"/file1", dstDir))
 }
 
 func TestExportStringToFileOutput(t *testing.T) {
 	tmpDir := t.TempDir()
 	envmanStorePath := export.SetupEnvman(t)
 
-	e := export.NewExporter((command.NewFactory(env.NewRepository())), export.NewFileManager())
-	require.NoError(t, e.ExportStringToFileOutput("ENV_KEY", "content", tmpDir+"/file.txt", nil))
+	e := export.NewExporter(command.NewFactory(env.NewRepository()), export.NewFileManager())
+	require.NoError(t, e.ExportStringToFileOutput("ENV_KEY", "content", tmpDir+"/file.txt"))
 	export.RequireEnvmanContainsValueForKey(t, "ENV_KEY", tmpDir+"/file.txt", false, envmanStorePath)
 
 	assert.NoError(t, internaltesting.NewFileChecker(tmpDir+"/file.txt").IsFile().Check())
@@ -251,8 +251,8 @@ line 5
 
 `
 
-	e := export.NewExporter((command.NewFactory(env.NewRepository())), export.NewFileManager())
-	lines, err := e.ExportStringToFileOutputAndReturnLastNLines("ENV_KEY", content, tmpDir+"/file.txt", 4, nil)
+	e := export.NewExporter(command.NewFactory(env.NewRepository()), export.NewFileManager())
+	lines, err := e.ExportStringToFileOutputAndReturnLastNLines("ENV_KEY", content, tmpDir+"/file.txt", 4)
 	require.NoError(t, err)
 	export.RequireEnvmanContainsValueForKey(t, "ENV_KEY", tmpDir+"/file.txt", false, envmanStorePath)
 
@@ -272,7 +272,7 @@ func TestExportOutputDir_GivenLStatSrcFails_Fails(t *testing.T) {
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 
 	fileManager.EXPECT().Lstat(srcDir).Return(nil, fmt.Errorf("test"))
-	assert.ErrorContains(t, sut.ExportOutputDir("ENV_KEY", srcDir, dstDir, nil), "test")
+	assert.ErrorContains(t, sut.ExportOutputDir("ENV_KEY", srcDir, dstDir), "test")
 }
 
 func TestExportOutputDir_GivenMatchingSrcAndDst_SkipsCopy(t *testing.T) {
@@ -285,7 +285,7 @@ func TestExportOutputDir_GivenMatchingSrcAndDst_SkipsCopy(t *testing.T) {
 	srcDir := export.CreateSrcDirWithFiles(t, tmpDir, []string{"file1", "file2", "file3"})
 
 	fileManager.EXPECT().Lstat(srcDir).Return(os.Stat(srcDir))
-	assert.NoError(t, sut.ExportOutputDir("ENV_KEY", srcDir, srcDir, nil), "test")
+	assert.NoError(t, sut.ExportOutputDir("ENV_KEY", srcDir, srcDir), "test")
 	export.RequireEnvmanContainsValueForKey(t, "ENV_KEY", srcDir, false, envmanStorePath)
 }
 
@@ -302,7 +302,7 @@ func TestExportOutputDir_GivenFileManagerCopyFails_Fails(t *testing.T) {
 	fileManager.EXPECT().Lstat(srcDir).Return(os.Lstat(srcDir))
 	fileManager.EXPECT().CopyDir(srcDir, dstDir, mock.Anything).Return(fmt.Errorf("test"))
 
-	assert.ErrorContains(t, sut.ExportOutputDir("ENV_KEY", srcDir, dstDir, nil), "test")
+	assert.ErrorContains(t, sut.ExportOutputDir("ENV_KEY", srcDir, dstDir), "test")
 }
 
 func TestExportStringToFileOutput_GivenWriteBytesFails_WillFail(t *testing.T) {
@@ -314,5 +314,5 @@ func TestExportStringToFileOutput_GivenWriteBytesFails_WillFail(t *testing.T) {
 
 	fileManager.EXPECT().WriteBytes(tmpDir+"/file.txt", []byte("content")).Return(fmt.Errorf("test"))
 
-	require.ErrorContains(t, sut.ExportStringToFileOutput("ENV_KEY", "content", tmpDir+"/file.txt", nil), "test")
+	require.ErrorContains(t, sut.ExportStringToFileOutput("ENV_KEY", "content", tmpDir+"/file.txt"), "test")
 }

--- a/export/export_test.go
+++ b/export/export_test.go
@@ -1,12 +1,12 @@
-package export
+package export_test
 
 import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
+	"github.com/bitrise-io/go-steputils/v2/export"
 	"github.com/bitrise-io/go-steputils/v2/export/mocks"
 	internaltesting "github.com/bitrise-io/go-steputils/v2/internal/testing"
 
@@ -19,75 +19,69 @@ import (
 )
 
 func TestExportOutput(t *testing.T) {
-	envmanStorePath := setupEnvman(t)
+	envmanStorePath := export.SetupEnvman(t)
 
-	e := NewExporter(command.NewFactory(env.NewRepository()))
+	e := export.NewExporter(command.NewFactory(env.NewRepository()))
 	require.NoError(t, e.ExportOutput("my_key", "my value"))
 
-	requireEnvmanContainsValueForKey(t, "my_key", "my value", false, envmanStorePath)
+	export.RequireEnvmanContainsValueForKey(t, "my_key", "my value", false, envmanStorePath)
 }
 
 func TestExportSecretOutput(t *testing.T) {
-	envmanStorePath := setupEnvman(t)
+	envmanStorePath := export.SetupEnvman(t)
 
-	e := NewExporter(command.NewFactory(env.NewRepository()))
+	e := export.NewExporter(command.NewFactory(env.NewRepository()))
 	require.NoError(t, e.ExportSecretOutput("my_key", "my secret value"))
 
-	requireEnvmanContainsValueForKey(t, "my_key", "my secret value", true, envmanStorePath)
+	export.RequireEnvmanContainsValueForKey(t, "my_key", "my secret value", true, envmanStorePath)
 }
 
 func TestExportOutputFile(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	envmanStorePath := setupEnvman(t)
+	envmanStorePath := export.SetupEnvman(t)
 
 	sourcePath := filepath.Join(tmpDir, "test_file_source")
 	destinationPath := filepath.Join(tmpDir, "test_file_destination")
 	require.NoError(t, os.WriteFile(sourcePath, []byte("hello"), 0700))
 
-	e := NewExporter(command.NewFactory(env.NewRepository()))
-	require.NoError(t, e.ExportOutputFile("my_key", sourcePath, destinationPath))
+	e := export.NewExporter(command.NewFactory(env.NewRepository()))
+	require.NoError(t, e.ExportOutputFile("my_key", sourcePath, destinationPath, nil))
 
-	requireEnvmanContainsValueForKey(t, "my_key", destinationPath, false, envmanStorePath)
+	export.RequireEnvmanContainsValueForKey(t, "my_key", destinationPath, false, envmanStorePath)
 }
 
 func TestExportOutputFile_GivenCopyFails_WillFail(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	_ = setupEnvman(t)
+	_ = export.SetupEnvman(t)
 	fileManager := mocks.NewFileManager(t)
-	sut := Exporter{
-		cmdFactory:  command.NewFactory(env.NewRepository()),
-		fileManager: fileManager,
-	}
-	fileManager.EXPECT().CopyFile(mock.Anything, mock.Anything).Return(fmt.Errorf("test"))
+	sut := export.NewExporterWithFileManager(command.NewFactory(env.NewRepository()), fileManager)
+	fileManager.EXPECT().CopyFile(mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("test"))
 
-	srcDir := createSrcDirWithFiles(t, tmpDir, []string{"file1", "file2", "file3"})
+	srcDir := export.CreateSrcDirWithFiles(t, tmpDir, []string{"file1", "file2", "file3"})
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 
-	require.ErrorContains(t, sut.ExportOutputFile("my_key", srcDir, dstDir), "test")
+	require.ErrorContains(t, sut.ExportOutputFile("my_key", srcDir, dstDir, nil), "test")
 }
 
 func TestExportOutputFile_GivenSameSrcAndDst_SkipsCopy(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	envmanStorePath := setupEnvman(t)
+	envmanStorePath := export.SetupEnvman(t)
 	fileManager := mocks.NewFileManager(t)
-	sut := Exporter{
-		cmdFactory:  command.NewFactory(env.NewRepository()),
-		fileManager: fileManager,
-	}
+	sut := export.NewExporterWithFileManager(command.NewFactory(env.NewRepository()), fileManager)
 
-	srcDir := createSrcDirWithFiles(t, tmpDir, []string{"file1", "file2", "file3"})
+	srcDir := export.CreateSrcDirWithFiles(t, tmpDir, []string{"file1", "file2", "file3"})
 
-	require.NoError(t, sut.ExportOutputFile("my_key", srcDir, srcDir))
-	requireEnvmanContainsValueForKey(t, "my_key", srcDir, false, envmanStorePath)
+	require.NoError(t, sut.ExportOutputFile("my_key", srcDir, srcDir, nil))
+	export.RequireEnvmanContainsValueForKey(t, "my_key", srcDir, false, envmanStorePath)
 }
 
 func TestZipDirectoriesAndExportOutput(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	envmanStorePath := setupEnvman(t)
+	envmanStorePath := export.SetupEnvman(t)
 
 	sourceA := filepath.Join(tmpDir, "sourceA")
 	require.NoError(t, os.MkdirAll(sourceA, 0777))
@@ -98,8 +92,8 @@ func TestZipDirectoriesAndExportOutput(t *testing.T) {
 	destinationZip := filepath.Join(tmpDir, "destination.zip")
 
 	key := "EXPORTED_ZIP_PATH"
-	e := NewExporter(command.NewFactory(env.NewRepository()))
-	require.NoError(t, e.ExportOutputFilesZip(key, []string{sourceA, sourceB}, destinationZip))
+	e := export.NewExporter(command.NewFactory(env.NewRepository()))
+	require.NoError(t, e.ExportOutputFilesZip(key, []string{sourceA, sourceB}, destinationZip, nil))
 
 	// destination should exist
 	exist, err := pathutil.NewPathChecker().IsPathExists(destinationZip)
@@ -107,13 +101,13 @@ func TestZipDirectoriesAndExportOutput(t *testing.T) {
 	require.Equal(t, true, exist, tmpDir)
 
 	// destination should be exported
-	requireEnvmanContainsValueForKey(t, key, destinationZip, false, envmanStorePath)
+	export.RequireEnvmanContainsValueForKey(t, key, destinationZip, false, envmanStorePath)
 }
 
 func TestZipFilesAndExportOutput(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	envmanStorePath := setupEnvman(t)
+	envmanStorePath := export.SetupEnvman(t)
 
 	sourceDir := filepath.Join(tmpDir, "source")
 	require.NoError(t, os.MkdirAll(sourceDir, 0777))
@@ -129,8 +123,8 @@ func TestZipFilesAndExportOutput(t *testing.T) {
 	destinationZip := filepath.Join(tmpDir, "destination.zip")
 
 	key := "EXPORTED_ZIP_PATH"
-	e := NewExporter(command.NewFactory(env.NewRepository()))
-	require.NoError(t, e.ExportOutputFilesZip(key, sourceFilePaths, destinationZip))
+	e := export.NewExporter(command.NewFactory(env.NewRepository()))
+	require.NoError(t, e.ExportOutputFilesZip(key, sourceFilePaths, destinationZip, nil))
 
 	// destination should exist
 	exist, err := pathutil.NewPathChecker().IsPathExists(destinationZip)
@@ -138,13 +132,13 @@ func TestZipFilesAndExportOutput(t *testing.T) {
 	require.Equal(t, true, exist, tmpDir)
 
 	// destination should be exported
-	requireEnvmanContainsValueForKey(t, key, destinationZip, false, envmanStorePath)
+	export.RequireEnvmanContainsValueForKey(t, key, destinationZip, false, envmanStorePath)
 }
 
 func TestZipMixedFilesAndFoldersAndExportOutput(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	_ = setupEnvman(t)
+	_ = export.SetupEnvman(t)
 
 	sourceDir := filepath.Join(tmpDir, "source")
 	require.NoError(t, os.MkdirAll(sourceDir, 0777))
@@ -164,16 +158,16 @@ func TestZipMixedFilesAndFoldersAndExportOutput(t *testing.T) {
 
 	destinationZip := filepath.Join(tmpDir, "destination.zip")
 
-	e := NewExporter(command.NewFactory(env.NewRepository()))
-	require.Error(t, e.ExportOutputFilesZip("EXPORTED_ZIP_PATH", sourceFilePaths, destinationZip))
+	e := export.NewExporter(command.NewFactory(env.NewRepository()))
+	require.Error(t, e.ExportOutputFilesZip("EXPORTED_ZIP_PATH", sourceFilePaths, destinationZip, nil))
 }
 
 func TestExportOutputDirE2E(t *testing.T) {
 	tmpDir := t.TempDir()
-	envmanStorePath := setupEnvman(t)
+	envmanStorePath := export.SetupEnvman(t)
 
 	// umask in tmp is likely 022, so testing with compatible permissions (0700, 0755)
-	srcDir := createSrcDirWithFiles(t, tmpDir, []string{"file1", "file2", "file3"})
+	srcDir := export.CreateSrcDirWithFiles(t, tmpDir, []string{"file1", "file2", "file3"})
 	extraDir := filepath.Join(srcDir, "extraDir")
 	require.NoError(t, os.MkdirAll(extraDir, 0700))
 	linkTarget := filepath.Join(srcDir, "file1")
@@ -182,9 +176,9 @@ func TestExportOutputDirE2E(t *testing.T) {
 
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 
-	sut := NewExporter((command.NewFactory(env.NewRepository())))
-	assert.NoError(t, sut.ExportOutputDir("ENV_KEY", srcDir, dstDir))
-	requireEnvmanContainsValueForKey(t, "ENV_KEY", dstDir, false, envmanStorePath)
+	sut := export.NewExporter((command.NewFactory(env.NewRepository())))
+	assert.NoError(t, sut.ExportOutputDir("ENV_KEY", srcDir, dstDir, nil))
+	export.RequireEnvmanContainsValueForKey(t, "ENV_KEY", dstDir, false, envmanStorePath)
 
 	assert.NoError(t,
 		internaltesting.NewFileChecker(dstDir).IsDir().ModeEquals(0755).Check(),
@@ -208,36 +202,36 @@ func TestExportOutputDirE2E(t *testing.T) {
 
 func TestExportOutputDir_GivenSrcIsFile_Fails(t *testing.T) {
 	tmpDir := t.TempDir()
-	_ = setupEnvman(t)
+	_ = export.SetupEnvman(t)
 
-	srcDir := createSrcDirWithFiles(t, tmpDir, []string{"file1", "file2", "file3"})
+	srcDir := export.CreateSrcDirWithFiles(t, tmpDir, []string{"file1", "file2", "file3"})
 	extraDir := filepath.Join(srcDir, "empty-folder")
 	require.NoError(t, os.MkdirAll(extraDir, 0777))
 
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 
-	e := NewExporter((command.NewFactory(env.NewRepository())))
-	assert.Error(t, e.ExportOutputDir("ENV_KEY", srcDir+"/file1", dstDir))
+	e := export.NewExporter((command.NewFactory(env.NewRepository())))
+	assert.Error(t, e.ExportOutputDir("ENV_KEY", srcDir+"/file1", dstDir, nil))
 }
 
 func TestExportOutputDir_GivenMissingSrc_Fails(t *testing.T) {
 
 	tmpDir := t.TempDir()
-	_ = setupEnvman(t)
+	_ = export.SetupEnvman(t)
 
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 
-	e := NewExporter((command.NewFactory(env.NewRepository())))
-	assert.Error(t, e.ExportOutputDir("ENV_KEY", dstDir+"/file1", dstDir))
+	e := export.NewExporter((command.NewFactory(env.NewRepository())))
+	assert.Error(t, e.ExportOutputDir("ENV_KEY", dstDir+"/file1", dstDir, nil))
 }
 
 func TestExportStringToFileOutput(t *testing.T) {
 	tmpDir := t.TempDir()
-	envmanStorePath := setupEnvman(t)
+	envmanStorePath := export.SetupEnvman(t)
 
-	e := NewExporter((command.NewFactory(env.NewRepository())))
-	require.NoError(t, e.ExportStringToFileOutput("ENV_KEY", "content", tmpDir+"/file.txt"))
-	requireEnvmanContainsValueForKey(t, "ENV_KEY", tmpDir+"/file.txt", false, envmanStorePath)
+	e := export.NewExporter((command.NewFactory(env.NewRepository())))
+	require.NoError(t, e.ExportStringToFileOutput("ENV_KEY", "content", tmpDir+"/file.txt", nil))
+	export.RequireEnvmanContainsValueForKey(t, "ENV_KEY", tmpDir+"/file.txt", false, envmanStorePath)
 
 	assert.NoError(t, internaltesting.NewFileChecker(tmpDir+"/file.txt").IsFile().Check())
 	assert.NoError(t, internaltesting.NewFileChecker(tmpDir+"/file.txt").Content("content").Check())
@@ -245,7 +239,7 @@ func TestExportStringToFileOutput(t *testing.T) {
 
 func TestExportStringToFileOutputAndReturnLastNLines(t *testing.T) {
 	tmpDir := t.TempDir()
-	envmanStorePath := setupEnvman(t)
+	envmanStorePath := export.SetupEnvman(t)
 
 	content := `line 1
 line 2
@@ -257,10 +251,10 @@ line 5
 
 `
 
-	e := NewExporter((command.NewFactory(env.NewRepository())))
-	lines, err := e.ExportStringToFileOutputAndReturnLastNLines("ENV_KEY", content, tmpDir+"/file.txt", 4)
+	e := export.NewExporter((command.NewFactory(env.NewRepository())))
+	lines, err := e.ExportStringToFileOutputAndReturnLastNLines("ENV_KEY", content, tmpDir+"/file.txt", 4, nil)
 	require.NoError(t, err)
-	requireEnvmanContainsValueForKey(t, "ENV_KEY", tmpDir+"/file.txt", false, envmanStorePath)
+	export.RequireEnvmanContainsValueForKey(t, "ENV_KEY", tmpDir+"/file.txt", false, envmanStorePath)
 
 	assert.NoError(t, internaltesting.NewFileChecker(tmpDir+"/file.txt").IsFile().Check())
 	assert.NoError(t, internaltesting.NewFileChecker(tmpDir+"/file.txt").Content(content).Check())
@@ -269,120 +263,56 @@ line 5
 
 func TestExportOutputDir_GivenLStatSrcFails_Fails(t *testing.T) {
 	tmpDir := t.TempDir()
-	_ = setupEnvman(t)
+	_ = export.SetupEnvman(t)
 
 	fileManager := mocks.NewFileManager(t)
-	sut := Exporter{
-		cmdFactory:  command.NewFactory(env.NewRepository()),
-		fileManager: fileManager,
-	}
+	sut := export.NewExporterWithFileManager(command.NewFactory(env.NewRepository()), fileManager)
 
-	srcDir := createSrcDirWithFiles(t, tmpDir, []string{"file1", "file2", "file3"})
+	srcDir := export.CreateSrcDirWithFiles(t, tmpDir, []string{"file1", "file2", "file3"})
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 
 	fileManager.EXPECT().Lstat(srcDir).Return(nil, fmt.Errorf("test"))
-	assert.ErrorContains(t, sut.ExportOutputDir("ENV_KEY", srcDir, dstDir), "test")
+	assert.ErrorContains(t, sut.ExportOutputDir("ENV_KEY", srcDir, dstDir, nil), "test")
 }
 
 func TestExportOutputDir_GivenMatchingSrcAndDst_SkipsCopy(t *testing.T) {
 	tmpDir := t.TempDir()
-	envmanStorePath := setupEnvman(t)
+	envmanStorePath := export.SetupEnvman(t)
 
 	fileManager := mocks.NewFileManager(t)
-	sut := Exporter{
-		cmdFactory:  command.NewFactory(env.NewRepository()),
-		fileManager: fileManager,
-	}
+	sut := export.NewExporterWithFileManager(command.NewFactory(env.NewRepository()), fileManager)
 
-	srcDir := createSrcDirWithFiles(t, tmpDir, []string{"file1", "file2", "file3"})
+	srcDir := export.CreateSrcDirWithFiles(t, tmpDir, []string{"file1", "file2", "file3"})
 
 	fileManager.EXPECT().Lstat(srcDir).Return(os.Stat(srcDir))
-	assert.NoError(t, sut.ExportOutputDir("ENV_KEY", srcDir, srcDir), "test")
-	requireEnvmanContainsValueForKey(t, "ENV_KEY", srcDir, false, envmanStorePath)
+	assert.NoError(t, sut.ExportOutputDir("ENV_KEY", srcDir, srcDir, nil), "test")
+	export.RequireEnvmanContainsValueForKey(t, "ENV_KEY", srcDir, false, envmanStorePath)
 }
 
 func TestExportOutputDir_GivenFileManagerCopyFails_Fails(t *testing.T) {
 	tmpDir := t.TempDir()
-	_ = setupEnvman(t)
+	_ = export.SetupEnvman(t)
 
 	fileManager := mocks.NewFileManager(t)
-	sut := Exporter{
-		cmdFactory:  command.NewFactory(env.NewRepository()),
-		fileManager: fileManager,
-	}
+	sut := export.NewExporterWithFileManager(command.NewFactory(env.NewRepository()), fileManager)
 
-	srcDir := createSrcDirWithFiles(t, tmpDir, []string{"file1", "file2", "file3"})
+	srcDir := export.CreateSrcDirWithFiles(t, tmpDir, []string{"file1", "file2", "file3"})
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 
 	fileManager.EXPECT().Lstat(srcDir).Return(os.Lstat(srcDir))
-	fileManager.EXPECT().CopyDir(srcDir, dstDir).Return(fmt.Errorf("test"))
+	fileManager.EXPECT().CopyDir(srcDir, dstDir, mock.Anything).Return(fmt.Errorf("test"))
 
-	assert.ErrorContains(t, sut.ExportOutputDir("ENV_KEY", srcDir, dstDir), "test")
+	assert.ErrorContains(t, sut.ExportOutputDir("ENV_KEY", srcDir, dstDir, nil), "test")
 }
 
 func TestExportStringToFileOutput_GivenWriteBytesFails_WillFail(t *testing.T) {
 	tmpDir := t.TempDir()
-	_ = setupEnvman(t)
+	_ = export.SetupEnvman(t)
 
 	fileManager := mocks.NewFileManager(t)
-	sut := Exporter{
-		cmdFactory:  command.NewFactory(env.NewRepository()),
-		fileManager: fileManager,
-	}
+	sut := export.NewExporterWithFileManager(command.NewFactory(env.NewRepository()), fileManager)
 
 	fileManager.EXPECT().WriteBytes(tmpDir+"/file.txt", []byte("content")).Return(fmt.Errorf("test"))
 
-	require.ErrorContains(t, sut.ExportStringToFileOutput("ENV_KEY", "content", tmpDir+"/file.txt"), "test")
-}
-
-// ---------------------------
-// Helpers
-// ---------------------------
-
-func createSrcDirWithFiles(t *testing.T, baseDir string, fileNames []string) string {
-	t.Helper()
-	srcDir := filepath.Join(baseDir, "src-dir")
-	require.NoError(t, os.MkdirAll(srcDir, 0755))
-	for _, name := range fileNames {
-		sourceFile := filepath.Join(srcDir, name)
-		require.NoError(t, os.WriteFile(sourceFile, []byte(name), 0755))
-	}
-	return srcDir
-}
-
-func requireEnvmanContainsValueForKey(t *testing.T, key, value string, secret bool, envmanStorePath string) {
-	t.Helper()
-	b, err := os.ReadFile(envmanStorePath)
-	require.NoError(t, err)
-	envstoreContent := string(b)
-
-	t.Logf("envstoreContent: %s\n", envstoreContent)
-	require.Equal(t, true, strings.Contains(envstoreContent, "- "+key+": "+value), envstoreContent)
-
-	if secret {
-		require.Equal(t, true, strings.Contains(envstoreContent, "is_sensitive: true"), envstoreContent)
-	}
-}
-
-func setupEnvman(t *testing.T) string {
-	t.Helper()
-	originalWorkDir, err := os.Getwd()
-	require.NoError(t, err)
-
-	tmpDir := t.TempDir()
-	err = os.Chdir(tmpDir)
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		err = os.Chdir(originalWorkDir)
-		require.NoError(t, err)
-	})
-	require.NoError(t, err)
-
-	tmpEnvStorePth := filepath.Join(tmpDir, ".envstore.yml")
-	require.NoError(t, os.WriteFile(tmpEnvStorePth, []byte(""), 0777))
-
-	t.Setenv("ENVMAN_ENVSTORE_PATH", tmpEnvStorePth)
-
-	return tmpEnvStorePth
+	require.ErrorContains(t, sut.ExportStringToFileOutput("ENV_KEY", "content", tmpDir+"/file.txt", nil), "test")
 }

--- a/export/export_test.go
+++ b/export/export_test.go
@@ -21,7 +21,7 @@ import (
 func TestExportOutput(t *testing.T) {
 	envmanStorePath := export.SetupEnvman(t)
 
-	e := export.NewExporter(command.NewFactory(env.NewRepository()))
+	e := export.NewExporter(command.NewFactory(env.NewRepository()), export.NewFileManager())
 	require.NoError(t, e.ExportOutput("my_key", "my value"))
 
 	export.RequireEnvmanContainsValueForKey(t, "my_key", "my value", false, envmanStorePath)
@@ -30,7 +30,7 @@ func TestExportOutput(t *testing.T) {
 func TestExportSecretOutput(t *testing.T) {
 	envmanStorePath := export.SetupEnvman(t)
 
-	e := export.NewExporter(command.NewFactory(env.NewRepository()))
+	e := export.NewExporter(command.NewFactory(env.NewRepository()), export.NewFileManager())
 	require.NoError(t, e.ExportSecretOutput("my_key", "my secret value"))
 
 	export.RequireEnvmanContainsValueForKey(t, "my_key", "my secret value", true, envmanStorePath)
@@ -45,7 +45,7 @@ func TestExportOutputFile(t *testing.T) {
 	destinationPath := filepath.Join(tmpDir, "test_file_destination")
 	require.NoError(t, os.WriteFile(sourcePath, []byte("hello"), 0700))
 
-	e := export.NewExporter(command.NewFactory(env.NewRepository()))
+	e := export.NewExporter(command.NewFactory(env.NewRepository()), export.NewFileManager())
 	require.NoError(t, e.ExportOutputFile("my_key", sourcePath, destinationPath, nil))
 
 	export.RequireEnvmanContainsValueForKey(t, "my_key", destinationPath, false, envmanStorePath)
@@ -56,7 +56,7 @@ func TestExportOutputFile_GivenCopyFails_WillFail(t *testing.T) {
 
 	_ = export.SetupEnvman(t)
 	fileManager := mocks.NewFileManager(t)
-	sut := export.NewExporterWithFileManager(command.NewFactory(env.NewRepository()), fileManager)
+	sut := export.NewExporter(command.NewFactory(env.NewRepository()), fileManager)
 	fileManager.EXPECT().CopyFile(mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("test"))
 
 	srcDir := export.CreateSrcDirWithFiles(t, tmpDir, []string{"file1", "file2", "file3"})
@@ -70,7 +70,7 @@ func TestExportOutputFile_GivenSameSrcAndDst_SkipsCopy(t *testing.T) {
 
 	envmanStorePath := export.SetupEnvman(t)
 	fileManager := mocks.NewFileManager(t)
-	sut := export.NewExporterWithFileManager(command.NewFactory(env.NewRepository()), fileManager)
+	sut := export.NewExporter(command.NewFactory(env.NewRepository()), fileManager)
 
 	srcDir := export.CreateSrcDirWithFiles(t, tmpDir, []string{"file1", "file2", "file3"})
 
@@ -92,7 +92,7 @@ func TestZipDirectoriesAndExportOutput(t *testing.T) {
 	destinationZip := filepath.Join(tmpDir, "destination.zip")
 
 	key := "EXPORTED_ZIP_PATH"
-	e := export.NewExporter(command.NewFactory(env.NewRepository()))
+	e := export.NewExporter(command.NewFactory(env.NewRepository()), export.NewFileManager())
 	require.NoError(t, e.ExportOutputFilesZip(key, []string{sourceA, sourceB}, destinationZip, nil))
 
 	// destination should exist
@@ -123,7 +123,7 @@ func TestZipFilesAndExportOutput(t *testing.T) {
 	destinationZip := filepath.Join(tmpDir, "destination.zip")
 
 	key := "EXPORTED_ZIP_PATH"
-	e := export.NewExporter(command.NewFactory(env.NewRepository()))
+	e := export.NewExporter(command.NewFactory(env.NewRepository()), export.NewFileManager())
 	require.NoError(t, e.ExportOutputFilesZip(key, sourceFilePaths, destinationZip, nil))
 
 	// destination should exist
@@ -158,7 +158,7 @@ func TestZipMixedFilesAndFoldersAndExportOutput(t *testing.T) {
 
 	destinationZip := filepath.Join(tmpDir, "destination.zip")
 
-	e := export.NewExporter(command.NewFactory(env.NewRepository()))
+	e := export.NewExporter(command.NewFactory(env.NewRepository()), export.NewFileManager())
 	require.Error(t, e.ExportOutputFilesZip("EXPORTED_ZIP_PATH", sourceFilePaths, destinationZip, nil))
 }
 
@@ -176,7 +176,7 @@ func TestExportOutputDirE2E(t *testing.T) {
 
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 
-	sut := export.NewExporter((command.NewFactory(env.NewRepository())))
+	sut := export.NewExporter((command.NewFactory(env.NewRepository())), export.NewFileManager())
 	assert.NoError(t, sut.ExportOutputDir("ENV_KEY", srcDir, dstDir, nil))
 	export.RequireEnvmanContainsValueForKey(t, "ENV_KEY", dstDir, false, envmanStorePath)
 
@@ -210,7 +210,7 @@ func TestExportOutputDir_GivenSrcIsFile_Fails(t *testing.T) {
 
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 
-	e := export.NewExporter((command.NewFactory(env.NewRepository())))
+	e := export.NewExporter((command.NewFactory(env.NewRepository())), export.NewFileManager())
 	assert.Error(t, e.ExportOutputDir("ENV_KEY", srcDir+"/file1", dstDir, nil))
 }
 
@@ -221,7 +221,7 @@ func TestExportOutputDir_GivenMissingSrc_Fails(t *testing.T) {
 
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 
-	e := export.NewExporter((command.NewFactory(env.NewRepository())))
+	e := export.NewExporter((command.NewFactory(env.NewRepository())), export.NewFileManager())
 	assert.Error(t, e.ExportOutputDir("ENV_KEY", dstDir+"/file1", dstDir, nil))
 }
 
@@ -229,7 +229,7 @@ func TestExportStringToFileOutput(t *testing.T) {
 	tmpDir := t.TempDir()
 	envmanStorePath := export.SetupEnvman(t)
 
-	e := export.NewExporter((command.NewFactory(env.NewRepository())))
+	e := export.NewExporter((command.NewFactory(env.NewRepository())), export.NewFileManager())
 	require.NoError(t, e.ExportStringToFileOutput("ENV_KEY", "content", tmpDir+"/file.txt", nil))
 	export.RequireEnvmanContainsValueForKey(t, "ENV_KEY", tmpDir+"/file.txt", false, envmanStorePath)
 
@@ -251,7 +251,7 @@ line 5
 
 `
 
-	e := export.NewExporter((command.NewFactory(env.NewRepository())))
+	e := export.NewExporter((command.NewFactory(env.NewRepository())), export.NewFileManager())
 	lines, err := e.ExportStringToFileOutputAndReturnLastNLines("ENV_KEY", content, tmpDir+"/file.txt", 4, nil)
 	require.NoError(t, err)
 	export.RequireEnvmanContainsValueForKey(t, "ENV_KEY", tmpDir+"/file.txt", false, envmanStorePath)
@@ -266,7 +266,7 @@ func TestExportOutputDir_GivenLStatSrcFails_Fails(t *testing.T) {
 	_ = export.SetupEnvman(t)
 
 	fileManager := mocks.NewFileManager(t)
-	sut := export.NewExporterWithFileManager(command.NewFactory(env.NewRepository()), fileManager)
+	sut := export.NewExporter(command.NewFactory(env.NewRepository()), fileManager)
 
 	srcDir := export.CreateSrcDirWithFiles(t, tmpDir, []string{"file1", "file2", "file3"})
 	dstDir := filepath.Join(tmpDir, "dst-dir")
@@ -280,7 +280,7 @@ func TestExportOutputDir_GivenMatchingSrcAndDst_SkipsCopy(t *testing.T) {
 	envmanStorePath := export.SetupEnvman(t)
 
 	fileManager := mocks.NewFileManager(t)
-	sut := export.NewExporterWithFileManager(command.NewFactory(env.NewRepository()), fileManager)
+	sut := export.NewExporter(command.NewFactory(env.NewRepository()), fileManager)
 
 	srcDir := export.CreateSrcDirWithFiles(t, tmpDir, []string{"file1", "file2", "file3"})
 
@@ -294,7 +294,7 @@ func TestExportOutputDir_GivenFileManagerCopyFails_Fails(t *testing.T) {
 	_ = export.SetupEnvman(t)
 
 	fileManager := mocks.NewFileManager(t)
-	sut := export.NewExporterWithFileManager(command.NewFactory(env.NewRepository()), fileManager)
+	sut := export.NewExporter(command.NewFactory(env.NewRepository()), fileManager)
 
 	srcDir := export.CreateSrcDirWithFiles(t, tmpDir, []string{"file1", "file2", "file3"})
 	dstDir := filepath.Join(tmpDir, "dst-dir")
@@ -310,7 +310,7 @@ func TestExportStringToFileOutput_GivenWriteBytesFails_WillFail(t *testing.T) {
 	_ = export.SetupEnvman(t)
 
 	fileManager := mocks.NewFileManager(t)
-	sut := export.NewExporterWithFileManager(command.NewFactory(env.NewRepository()), fileManager)
+	sut := export.NewExporter(command.NewFactory(env.NewRepository()), fileManager)
 
 	fileManager.EXPECT().WriteBytes(tmpDir+"/file.txt", []byte("content")).Return(fmt.Errorf("test"))
 

--- a/export/file_manager.go
+++ b/export/file_manager.go
@@ -24,12 +24,18 @@ type SysStat struct {
 	Gid int
 }
 
+// CopyOptions configures a [FileManager.CopyFile] operation.
+// A nil pointer means default behavior.
+type CopyOptions struct {
+	Overwrite bool // Overwrite replaces the destination file if it already exists.
+}
+
 // FileManager defines file management operations.
 type FileManager interface {
 	fileutil.FileManager
 
-	CopyFile(src, dst string) error
-	CopyDir(src, dst string) error
+	CopyFile(src, dst string, opts *CopyOptions) error
+	CopyDir(src, dst string, opts *CopyOptions) error
 	Lstat(path string) (os.FileInfo, error)
 	LastNLines(s string, n int) string
 }
@@ -49,15 +55,21 @@ type fileManager struct {
 }
 
 // CopyFile copies a single file from src to dst.
-func (fm *fileManager) CopyFile(src, dst string) error {
+// Pass [CopyOptions] to modify default behavior as required, nil otherwise.
+//
+// Attention: the default behavior is different from the v1 implementation of `command.CopyFile`,
+// v1 function replaces the existing file.
+// By default, if the target file exists, this call will fail with an error.
+func (fm *fileManager) CopyFile(src, dst string, opts *CopyOptions) error {
 	srcDir := filepath.Dir(src)
 	fsys := fm.osProxy.DirFS(srcDir)
 
-	return fm.copyFileFS(fsys, filepath.Base(src), dst)
+	return fm.copyFileFS(fsys, filepath.Base(src), dst, opts)
 }
 
 // CopyFileFS is the excerpt from fs.CopyFS that copies a single file from fs.FS to dst path.
-func (fm *fileManager) copyFileFS(fsys fs.FS, src, dst string) error {
+// The [CopyOptions] parameter is used to modify default behavior as required or keep the default when nil is provided.
+func (fm *fileManager) copyFileFS(fsys fs.FS, src, dst string, opts *CopyOptions) error {
 	r, err := fsys.Open(src)
 	if err != nil {
 		return err
@@ -67,7 +79,11 @@ func (fm *fileManager) copyFileFS(fsys fs.FS, src, dst string) error {
 	if err != nil {
 		return err
 	}
-	w, err := fm.osProxy.OpenFile(dst, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0777)
+	flags := os.O_CREATE | os.O_EXCL | os.O_WRONLY
+	if opts != nil && opts.Overwrite {
+		flags = os.O_CREATE | os.O_TRUNC | os.O_WRONLY
+	}
+	w, err := fm.osProxy.OpenFile(dst, flags, 0777)
 	if err != nil {
 		return err
 	}
@@ -102,9 +118,11 @@ func (fm *fileManager) copyFileFS(fsys fs.FS, src, dst string) error {
 //
 // Preserves permissions and ownership when possible.
 //
-// CopyFS will not overwrite existing files. If a file name in fsys
+// By default, CopyFS will not overwrite existing files. If a file name in fsys
 // already exists in the destination, CopyFS will return an error
 // such that errors.Is(err, fs.ErrExist) will be true.
+// Attention: the default behavior is different from the v1 implementation of `command.CopyFile`,
+// v1 function replaces the existing files.
 //
 // Symbolic links in dir are followed.
 //
@@ -113,7 +131,7 @@ func (fm *fileManager) copyFileFS(fsys fs.FS, src, dst string) error {
 //
 // Copying stops at and returns the first error encountered.
 // Note: symlinks are preserved during the copy operation
-func (fm *fileManager) CopyDir(src, dst string) error {
+func (fm *fileManager) CopyDir(src, dst string, opts *CopyOptions) error {
 	fsys := fm.osProxy.DirFS(src)
 	return fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -156,7 +174,7 @@ func (fm *fileManager) CopyDir(src, dst string) error {
 			return fm.copyTimes(info, newPath)
 
 		case 0:
-			return fm.copyFileFS(fsys, path, newPath)
+			return fm.copyFileFS(fsys, path, newPath, opts)
 
 		default:
 			return &os.PathError{Op: "CopyFS", Path: path, Err: os.ErrInvalid}

--- a/export/file_manager_test.go
+++ b/export/file_manager_test.go
@@ -1,28 +1,25 @@
-package export
+package export_test
 
 import (
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/bitrise-io/go-steputils/v2/export"
 	"github.com/bitrise-io/go-steputils/v2/internal/mocks"
-	"github.com/bitrise-io/go-utils/v2/fileutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
 func TestCopyFile(t *testing.T) {
 	tmpDir := t.TempDir()
-	srcDir := createSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
+	srcDir := export.CreateSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 	assert.NoError(t, os.MkdirAll(dstDir, 0755))
 
 	osProxy := mocks.NewOsProxy(t)
 
-	sut := &fileManager{
-		wrapped: fileutil.NewFileManager(),
-		osProxy: osProxy,
-	}
+	sut := export.NewProxyFileManager(osProxy)
 
 	// Expect srcDir check
 	osProxy.EXPECT().DirFS(srcDir).Return(os.DirFS(srcDir)).Once()
@@ -38,21 +35,18 @@ func TestCopyFile(t *testing.T) {
 	osProxy.EXPECT().Chmod(filepath.Join(dstDir, "file1"), mock.Anything).Return(nil).Once()
 	osProxy.EXPECT().Chtimes(filepath.Join(dstDir, "file1"), mock.Anything, mock.Anything).Return(nil).Once()
 
-	assert.NoError(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1"))
+	assert.NoError(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1", nil))
 }
 
 func TestCopyFile_GivenDstFileOpenFailure_WillFail(t *testing.T) {
 	tmpDir := t.TempDir()
-	srcDir := createSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
+	srcDir := export.CreateSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 	assert.NoError(t, os.MkdirAll(dstDir, 0755))
 
 	osProxy := mocks.NewOsProxy(t)
 
-	sut := &fileManager{
-		wrapped: fileutil.NewFileManager(),
-		osProxy: osProxy,
-	}
+	sut := export.NewProxyFileManager(osProxy)
 
 	// Expect srcDir check
 	osProxy.EXPECT().DirFS(srcDir).Return(os.DirFS(srcDir)).Once()
@@ -63,21 +57,18 @@ func TestCopyFile_GivenDstFileOpenFailure_WillFail(t *testing.T) {
 		Return(nil, os.ErrPermission).
 		Once()
 
-	assert.ErrorContains(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1"), os.ErrPermission.Error())
+	assert.ErrorContains(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1", nil), os.ErrPermission.Error())
 }
 
 func TestCopyFile_GivenDstFileOwnershipChangeFailure_WillFail(t *testing.T) {
 	tmpDir := t.TempDir()
-	srcDir := createSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
+	srcDir := export.CreateSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 	assert.NoError(t, os.MkdirAll(dstDir, 0755))
 
 	osProxy := mocks.NewOsProxy(t)
 
-	sut := &fileManager{
-		wrapped: fileutil.NewFileManager(),
-		osProxy: osProxy,
-	}
+	sut := export.NewProxyFileManager(osProxy)
 
 	// Expect srcDir check
 	osProxy.EXPECT().DirFS(srcDir).Return(os.DirFS(srcDir)).Once()
@@ -91,21 +82,18 @@ func TestCopyFile_GivenDstFileOwnershipChangeFailure_WillFail(t *testing.T) {
 	// Expect dst file ownership, permissions and times to be set
 	osProxy.EXPECT().Lchown(filepath.Join(dstDir, "file1"), mock.Anything, mock.Anything).Return(os.ErrPermission).Once()
 
-	assert.ErrorContains(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1"), os.ErrPermission.Error())
+	assert.ErrorContains(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1", nil), os.ErrPermission.Error())
 }
 
 func TestCopyFile_GivenDstFileModeChangeFailure_WillFail(t *testing.T) {
 	tmpDir := t.TempDir()
-	srcDir := createSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
+	srcDir := export.CreateSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 	assert.NoError(t, os.MkdirAll(dstDir, 0755))
 
 	osProxy := mocks.NewOsProxy(t)
 
-	sut := &fileManager{
-		wrapped: fileutil.NewFileManager(),
-		osProxy: osProxy,
-	}
+	sut := export.NewProxyFileManager(osProxy)
 
 	// Expect srcDir check
 	osProxy.EXPECT().DirFS(srcDir).Return(os.DirFS(srcDir)).Once()
@@ -120,21 +108,18 @@ func TestCopyFile_GivenDstFileModeChangeFailure_WillFail(t *testing.T) {
 	osProxy.EXPECT().Lchown(filepath.Join(dstDir, "file1"), mock.Anything, mock.Anything).Return(nil).Once()
 	osProxy.EXPECT().Chmod(filepath.Join(dstDir, "file1"), mock.Anything).Return(os.ErrPermission).Once()
 
-	assert.ErrorContains(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1"), os.ErrPermission.Error())
+	assert.ErrorContains(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1", nil), os.ErrPermission.Error())
 }
 
 func TestCopyFile_GivenDstFileTimesChangeFailure_WillFail(t *testing.T) {
 	tmpDir := t.TempDir()
-	srcDir := createSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
+	srcDir := export.CreateSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 	assert.NoError(t, os.MkdirAll(dstDir, 0755))
 
 	osProxy := mocks.NewOsProxy(t)
 
-	sut := &fileManager{
-		wrapped: fileutil.NewFileManager(),
-		osProxy: osProxy,
-	}
+	sut := export.NewProxyFileManager(osProxy)
 
 	// Expect srcDir check
 	osProxy.EXPECT().DirFS(srcDir).Return(os.DirFS(srcDir)).Once()
@@ -150,12 +135,12 @@ func TestCopyFile_GivenDstFileTimesChangeFailure_WillFail(t *testing.T) {
 	osProxy.EXPECT().Chmod(filepath.Join(dstDir, "file1"), mock.Anything).Return(nil).Once()
 	osProxy.EXPECT().Chtimes(filepath.Join(dstDir, "file1"), mock.Anything, mock.Anything).Return(os.ErrPermission).Once()
 
-	assert.ErrorContains(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1"), os.ErrPermission.Error())
+	assert.ErrorContains(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1", nil), os.ErrPermission.Error())
 }
 
 func TestCopyDir(t *testing.T) {
 	tmpDir := t.TempDir()
-	srcDir := createSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
+	srcDir := export.CreateSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 	assert.NoError(t, os.MkdirAll(dstDir, 0755))
 	linkTarget := filepath.Join(srcDir, "file1")
@@ -163,10 +148,7 @@ func TestCopyDir(t *testing.T) {
 
 	osProxy := mocks.NewOsProxy(t)
 
-	sut := &fileManager{
-		wrapped: fileutil.NewFileManager(),
-		osProxy: osProxy,
-	}
+	sut := export.NewProxyFileManager(osProxy)
 
 	// Expect changes for dstDir
 	osProxy.EXPECT().MkdirAll(dstDir, mock.Anything).Return(nil).Once()
@@ -189,21 +171,18 @@ func TestCopyDir(t *testing.T) {
 	osProxy.EXPECT().Symlink(linkTarget, filepath.Join(dstDir, "link")).Return(nil).Once()
 	osProxy.EXPECT().Lchown(filepath.Join(dstDir, "link"), mock.Anything, mock.Anything).Return(nil).Once()
 
-	assert.NoError(t, sut.CopyDir(srcDir, dstDir))
+	assert.NoError(t, sut.CopyDir(srcDir, dstDir, nil))
 }
 
 func TestCopyDir_GivenDstDirCreationFailure_WillFail(t *testing.T) {
 	tmpDir := t.TempDir()
-	srcDir := createSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
+	srcDir := export.CreateSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 	assert.NoError(t, os.MkdirAll(dstDir, 0755))
 
 	osProxy := mocks.NewOsProxy(t)
 
-	sut := &fileManager{
-		wrapped: fileutil.NewFileManager(),
-		osProxy: osProxy,
-	}
+	sut := export.NewProxyFileManager(osProxy)
 
 	// Expect changes for dstDir
 	osProxy.EXPECT().MkdirAll(dstDir, mock.Anything).Return(os.ErrPermission).Once()
@@ -211,21 +190,18 @@ func TestCopyDir_GivenDstDirCreationFailure_WillFail(t *testing.T) {
 	// Expect file copy expectations for file1
 	osProxy.EXPECT().DirFS(srcDir).Return(os.DirFS(srcDir)).Once()
 
-	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir), os.ErrPermission.Error())
+	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir, nil), os.ErrPermission.Error())
 }
 
 func TestCopyDir_GivenDstOwnershipChangeFailure_WillFail(t *testing.T) {
 	tmpDir := t.TempDir()
-	srcDir := createSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
+	srcDir := export.CreateSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 	assert.NoError(t, os.MkdirAll(dstDir, 0755))
 
 	osProxy := mocks.NewOsProxy(t)
 
-	sut := &fileManager{
-		wrapped: fileutil.NewFileManager(),
-		osProxy: osProxy,
-	}
+	sut := export.NewProxyFileManager(osProxy)
 
 	// Expect changes for dstDir
 	osProxy.EXPECT().MkdirAll(dstDir, mock.Anything).Return(nil).Once()
@@ -234,21 +210,18 @@ func TestCopyDir_GivenDstOwnershipChangeFailure_WillFail(t *testing.T) {
 	// Expect file copy expectations for file1
 	osProxy.EXPECT().DirFS(srcDir).Return(os.DirFS(srcDir)).Once()
 
-	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir), os.ErrPermission.Error())
+	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir, nil), os.ErrPermission.Error())
 }
 
 func TestCopyDir_GivenDstModeChangeFailure_WillFail(t *testing.T) {
 	tmpDir := t.TempDir()
-	srcDir := createSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
+	srcDir := export.CreateSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 	assert.NoError(t, os.MkdirAll(dstDir, 0755))
 
 	osProxy := mocks.NewOsProxy(t)
 
-	sut := &fileManager{
-		wrapped: fileutil.NewFileManager(),
-		osProxy: osProxy,
-	}
+	sut := export.NewProxyFileManager(osProxy)
 
 	// Expect changes for dstDir
 	osProxy.EXPECT().MkdirAll(dstDir, mock.Anything).Return(nil).Once()
@@ -258,21 +231,18 @@ func TestCopyDir_GivenDstModeChangeFailure_WillFail(t *testing.T) {
 	// Expect file copy expectations for file1
 	osProxy.EXPECT().DirFS(srcDir).Return(os.DirFS(srcDir)).Once()
 
-	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir), os.ErrPermission.Error())
+	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir, nil), os.ErrPermission.Error())
 }
 
 func TestCopyDir_GivenDstTimesChangeFailure_WillFail(t *testing.T) {
 	tmpDir := t.TempDir()
-	srcDir := createSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
+	srcDir := export.CreateSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 	assert.NoError(t, os.MkdirAll(dstDir, 0755))
 
 	osProxy := mocks.NewOsProxy(t)
 
-	sut := &fileManager{
-		wrapped: fileutil.NewFileManager(),
-		osProxy: osProxy,
-	}
+	sut := export.NewProxyFileManager(osProxy)
 
 	// Expect changes for dstDir
 	osProxy.EXPECT().MkdirAll(dstDir, mock.Anything).Return(nil).Once()
@@ -283,12 +253,12 @@ func TestCopyDir_GivenDstTimesChangeFailure_WillFail(t *testing.T) {
 	// Expect file copy expectations for file1
 	osProxy.EXPECT().DirFS(srcDir).Return(os.DirFS(srcDir)).Once()
 
-	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir), os.ErrPermission.Error())
+	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir, nil), os.ErrPermission.Error())
 }
 
 func TestCopyDir_GivenReadLinkFailure_WillFail(t *testing.T) {
 	tmpDir := t.TempDir()
-	srcDir := createSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
+	srcDir := export.CreateSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 	assert.NoError(t, os.MkdirAll(dstDir, 0755))
 	linkTarget := filepath.Join(srcDir, "file1")
@@ -296,10 +266,7 @@ func TestCopyDir_GivenReadLinkFailure_WillFail(t *testing.T) {
 
 	osProxy := mocks.NewOsProxy(t)
 
-	sut := &fileManager{
-		wrapped: fileutil.NewFileManager(),
-		osProxy: osProxy,
-	}
+	sut := export.NewProxyFileManager(osProxy)
 
 	// Expect changes for dstDir
 	osProxy.EXPECT().MkdirAll(dstDir, mock.Anything).Return(nil).Once()
@@ -322,12 +289,12 @@ func TestCopyDir_GivenReadLinkFailure_WillFail(t *testing.T) {
 	// osProxy.EXPECT().Symlink(linkTarget, filepath.Join(dstDir, "link")).Return(nil).Once()
 	// osProxy.EXPECT().Lchown(filepath.Join(dstDir, "link"), mock.Anything, mock.Anything).Return(nil).Once()
 
-	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir), os.ErrPermission.Error())
+	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir, nil), os.ErrPermission.Error())
 }
 
 func TestCopyDir_SymlinkFailure_WillFail(t *testing.T) {
 	tmpDir := t.TempDir()
-	srcDir := createSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
+	srcDir := export.CreateSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 	assert.NoError(t, os.MkdirAll(dstDir, 0755))
 	linkTarget := filepath.Join(srcDir, "file1")
@@ -335,10 +302,7 @@ func TestCopyDir_SymlinkFailure_WillFail(t *testing.T) {
 
 	osProxy := mocks.NewOsProxy(t)
 
-	sut := &fileManager{
-		wrapped: fileutil.NewFileManager(),
-		osProxy: osProxy,
-	}
+	sut := export.NewProxyFileManager(osProxy)
 
 	// Expect changes for dstDir
 	osProxy.EXPECT().MkdirAll(dstDir, mock.Anything).Return(nil).Once()
@@ -361,12 +325,12 @@ func TestCopyDir_SymlinkFailure_WillFail(t *testing.T) {
 	osProxy.EXPECT().Symlink(linkTarget, filepath.Join(dstDir, "link")).Return(os.ErrPermission).Once()
 	// osProxy.EXPECT().Lchown(filepath.Join(dstDir, "link"), mock.Anything, mock.Anything).Return(nil).Once()
 
-	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir), os.ErrPermission.Error())
+	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir, nil), os.ErrPermission.Error())
 }
 
 func TestCopyDir_SymlinkLChownFailure_WillFail(t *testing.T) {
 	tmpDir := t.TempDir()
-	srcDir := createSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
+	srcDir := export.CreateSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 	assert.NoError(t, os.MkdirAll(dstDir, 0755))
 	linkTarget := filepath.Join(srcDir, "file1")
@@ -374,10 +338,7 @@ func TestCopyDir_SymlinkLChownFailure_WillFail(t *testing.T) {
 
 	osProxy := mocks.NewOsProxy(t)
 
-	sut := &fileManager{
-		wrapped: fileutil.NewFileManager(),
-		osProxy: osProxy,
-	}
+	sut := export.NewProxyFileManager(osProxy)
 
 	// Expect changes for dstDir
 	osProxy.EXPECT().MkdirAll(dstDir, mock.Anything).Return(nil).Once()
@@ -400,5 +361,42 @@ func TestCopyDir_SymlinkLChownFailure_WillFail(t *testing.T) {
 	osProxy.EXPECT().Symlink(linkTarget, filepath.Join(dstDir, "link")).Return(nil).Once()
 	osProxy.EXPECT().Lchown(filepath.Join(dstDir, "link"), mock.Anything, mock.Anything).Return(os.ErrPermission).Once()
 
-	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir), os.ErrPermission.Error())
+	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir, nil), os.ErrPermission.Error())
+}
+
+func TestCopyFile_GivenDestinationExists_WillFail(t *testing.T) {
+	srcDir := export.CreateSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
+	dstDir := export.CreateSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
+
+	osProxy := mocks.NewOsProxy(t)
+
+	sut := export.NewProxyFileManager(osProxy)
+
+	osProxy.EXPECT().DirFS(srcDir).Return(os.DirFS(srcDir)).Once()
+	osProxy.EXPECT().
+		OpenFile(filepath.Join(dstDir, "file1"), os.O_CREATE|os.O_EXCL|os.O_WRONLY, mock.Anything).
+		Return(nil, os.ErrExist).
+		Once()
+
+	assert.ErrorIs(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1", nil), os.ErrExist)
+}
+
+func TestCopyFile_GivenDestinationExistsAndOverwriteOption_WillSucceed(t *testing.T) {
+	srcDir := export.CreateSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
+	dstDir := export.CreateSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
+
+	osProxy := mocks.NewOsProxy(t)
+
+	sut := export.NewProxyFileManager(osProxy)
+
+	osProxy.EXPECT().DirFS(srcDir).Return(os.DirFS(srcDir)).Once()
+	osProxy.EXPECT().
+		OpenFile(filepath.Join(dstDir, "file1"), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mock.Anything).
+		Return(os.OpenFile(filepath.Join(dstDir, "file1"), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0o777))).
+		Once()
+	osProxy.EXPECT().Lchown(filepath.Join(dstDir, "file1"), mock.Anything, mock.Anything).Return(nil).Once()
+	osProxy.EXPECT().Chmod(filepath.Join(dstDir, "file1"), mock.Anything).Return(nil).Once()
+	osProxy.EXPECT().Chtimes(filepath.Join(dstDir, "file1"), mock.Anything, mock.Anything).Return(nil).Once()
+
+	assert.NoError(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1", &export.CopyOptions{Overwrite: true}))
 }

--- a/export/mocks/FileManager.go
+++ b/export/mocks/FileManager.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/bitrise-io/go-steputils/v2/export"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -39,16 +40,16 @@ func (_m *FileManager) EXPECT() *FileManager_Expecter {
 }
 
 // CopyDir provides a mock function for the type FileManager
-func (_mock *FileManager) CopyDir(src string, dst string) error {
-	ret := _mock.Called(src, dst)
+func (_mock *FileManager) CopyDir(src string, dst string, opts *export.CopyOptions) error {
+	ret := _mock.Called(src, dst, opts)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CopyDir")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
-		r0 = returnFunc(src, dst)
+	if returnFunc, ok := ret.Get(0).(func(string, string, *export.CopyOptions) error); ok {
+		r0 = returnFunc(src, dst, opts)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -63,11 +64,12 @@ type FileManager_CopyDir_Call struct {
 // CopyDir is a helper method to define mock.On call
 //   - src string
 //   - dst string
-func (_e *FileManager_Expecter) CopyDir(src interface{}, dst interface{}) *FileManager_CopyDir_Call {
-	return &FileManager_CopyDir_Call{Call: _e.mock.On("CopyDir", src, dst)}
+//   - opts *export.CopyOptions
+func (_e *FileManager_Expecter) CopyDir(src interface{}, dst interface{}, opts interface{}) *FileManager_CopyDir_Call {
+	return &FileManager_CopyDir_Call{Call: _e.mock.On("CopyDir", src, dst, opts)}
 }
 
-func (_c *FileManager_CopyDir_Call) Run(run func(src string, dst string)) *FileManager_CopyDir_Call {
+func (_c *FileManager_CopyDir_Call) Run(run func(src string, dst string, opts *export.CopyOptions)) *FileManager_CopyDir_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -77,9 +79,14 @@ func (_c *FileManager_CopyDir_Call) Run(run func(src string, dst string)) *FileM
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 *export.CopyOptions
+		if args[2] != nil {
+			arg2 = args[2].(*export.CopyOptions)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -90,22 +97,22 @@ func (_c *FileManager_CopyDir_Call) Return(err error) *FileManager_CopyDir_Call 
 	return _c
 }
 
-func (_c *FileManager_CopyDir_Call) RunAndReturn(run func(src string, dst string) error) *FileManager_CopyDir_Call {
+func (_c *FileManager_CopyDir_Call) RunAndReturn(run func(src string, dst string, opts *export.CopyOptions) error) *FileManager_CopyDir_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // CopyFile provides a mock function for the type FileManager
-func (_mock *FileManager) CopyFile(src string, dst string) error {
-	ret := _mock.Called(src, dst)
+func (_mock *FileManager) CopyFile(src string, dst string, opts *export.CopyOptions) error {
+	ret := _mock.Called(src, dst, opts)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CopyFile")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
-		r0 = returnFunc(src, dst)
+	if returnFunc, ok := ret.Get(0).(func(string, string, *export.CopyOptions) error); ok {
+		r0 = returnFunc(src, dst, opts)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -120,11 +127,12 @@ type FileManager_CopyFile_Call struct {
 // CopyFile is a helper method to define mock.On call
 //   - src string
 //   - dst string
-func (_e *FileManager_Expecter) CopyFile(src interface{}, dst interface{}) *FileManager_CopyFile_Call {
-	return &FileManager_CopyFile_Call{Call: _e.mock.On("CopyFile", src, dst)}
+//   - opts *export.CopyOptions
+func (_e *FileManager_Expecter) CopyFile(src interface{}, dst interface{}, opts interface{}) *FileManager_CopyFile_Call {
+	return &FileManager_CopyFile_Call{Call: _e.mock.On("CopyFile", src, dst, opts)}
 }
 
-func (_c *FileManager_CopyFile_Call) Run(run func(src string, dst string)) *FileManager_CopyFile_Call {
+func (_c *FileManager_CopyFile_Call) Run(run func(src string, dst string, opts *export.CopyOptions)) *FileManager_CopyFile_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -134,9 +142,14 @@ func (_c *FileManager_CopyFile_Call) Run(run func(src string, dst string)) *File
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 *export.CopyOptions
+		if args[2] != nil {
+			arg2 = args[2].(*export.CopyOptions)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -147,7 +160,7 @@ func (_c *FileManager_CopyFile_Call) Return(err error) *FileManager_CopyFile_Cal
 	return _c
 }
 
-func (_c *FileManager_CopyFile_Call) RunAndReturn(run func(src string, dst string) error) *FileManager_CopyFile_Call {
+func (_c *FileManager_CopyFile_Call) RunAndReturn(run func(src string, dst string, opts *export.CopyOptions) error) *FileManager_CopyFile_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/export/testhelpers_test.go
+++ b/export/testhelpers_test.go
@@ -1,0 +1,73 @@
+package export
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bitrise-io/go-steputils/v2/internal"
+	"github.com/bitrise-io/go-utils/v2/fileutil"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------
+// Bridging test file between export and export_test packages for helpers.
+// This enables export_test.go and file_manager_test.go to be gray box tests rather than white box.
+// ---------
+
+func CreateSrcDirWithFiles(t *testing.T, baseDir string, fileNames []string) string {
+	t.Helper()
+	srcDir := filepath.Join(baseDir, "src-dir")
+	require.NoError(t, os.MkdirAll(srcDir, 0755))
+	for _, name := range fileNames {
+		sourceFile := filepath.Join(srcDir, name)
+		require.NoError(t, os.WriteFile(sourceFile, []byte(name), 0755))
+	}
+	return srcDir
+}
+
+func RequireEnvmanContainsValueForKey(t *testing.T, key, value string, secret bool, envmanStorePath string) {
+	t.Helper()
+	b, err := os.ReadFile(envmanStorePath)
+	require.NoError(t, err)
+	envstoreContent := string(b)
+
+	t.Logf("envstoreContent: %s\n", envstoreContent)
+	require.Equal(t, true, strings.Contains(envstoreContent, "- "+key+": "+value), envstoreContent)
+
+	if secret {
+		require.Equal(t, true, strings.Contains(envstoreContent, "is_sensitive: true"), envstoreContent)
+	}
+}
+
+func SetupEnvman(t *testing.T) string {
+	t.Helper()
+	originalWorkDir, err := os.Getwd()
+	require.NoError(t, err)
+
+	tmpDir := t.TempDir()
+	err = os.Chdir(tmpDir)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err = os.Chdir(originalWorkDir)
+		require.NoError(t, err)
+	})
+	require.NoError(t, err)
+
+	tmpEnvStorePth := filepath.Join(tmpDir, ".envstore.yml")
+	require.NoError(t, os.WriteFile(tmpEnvStorePth, []byte(""), 0777))
+
+	t.Setenv("ENVMAN_ENVSTORE_PATH", tmpEnvStorePth)
+
+	return tmpEnvStorePth
+}
+
+// NewProxyFileManager creates a FileManager with customs proxy internals, useful for testing.
+func NewProxyFileManager(osProxy internal.OsProxy) FileManager {
+	return &fileManager{
+		wrapped: fileutil.NewFileManager(),
+		osProxy: osProxy,
+	}
+}

--- a/stepenv/stepenv.go
+++ b/stepenv/stepenv.go
@@ -10,7 +10,7 @@ import (
 func NewRepository(osRepository env.Repository) env.Repository {
 	return defaultRepository{
 		osRepository: osRepository,
-		exporter:     export.NewExporter(command.NewFactory(osRepository)),
+		exporter:     export.NewExporter(command.NewFactory(osRepository), export.NewFileManager()),
 	}
 }
 


### PR DESCRIPTION
feat: Add option to overwrite files on filemanager.Copy* actions
- Default behavior of NOT overwriting still stands
- Added CopyOptions struct to enable changing defaults
- Clarified docs
- Updated tests, there were some packaging and helper changes to support incorporating CopyOptions