### PR TITLE
Remove Auth Service token generation from CI

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -21,8 +21,6 @@ workflows:
     - go-test: { }
 
   test_integration:
-    before_run:
-    - _generate_cache_api_token
     steps:
     - script:
         title: Integration tests
@@ -36,26 +34,3 @@ workflows:
             #!/bin/bash
             set -ex
             go test -v -tags integration ./integration
-
-  _generate_cache_api_token:
-    steps:
-    - script:
-        title: Generate cache API access token
-        description: Generate an expiring API token using $API_CLIENT_SECRET
-        inputs:
-        - content: |
-            #!/bin/env bash
-            set -e
-
-            json_response=$(curl --fail -X POST https://auth.services.bitrise.io/auth/realms/bitrise-services/protocol/openid-connect/token -k \
-                --data "client_id=bitrise-steps" \
-                --data "client_secret=$CACHE_API_CLIENT_SECRET" \
-                --data "grant_type=urn:ietf:params:oauth:grant-type:uma-ticket" \
-                --data "claim_token=eyJhcHBfaWQiOlsiMzYxNzJhODkyMTU1OTk1MSJdLCAib3JnX2lkIjpbIjg2NGMyZmViOTE0YzI2MTUiXSwgImFiY3NfYWNjZXNzX2dyYW50ZWQiOlsidHJ1ZSJdfQ==" \
-                --data "claim_token_format=urn:ietf:params:oauth:token-type:jwt" \
-                --data "audience=bitrise-services")
-
-            auth_token=$(echo $json_response | jq -r .access_token)
-
-            envman add --key BITRISEIO_ABCS_API_URL --value $CACHE_API_URL
-            envman add --key BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN --value $auth_token --sensitive


### PR DESCRIPTION
## Summary
- Remove the `_generate_cache_api_token` utility workflow that requests UMA tokens from `auth.services.bitrise.io` via the `bitrise-steps` client
- Remove the `before_run` reference to `_generate_cache_api_token` from the `test_integration` workflow

Part of the broader migration away from Auth Service tokens ([tracking context](https://github.com/bitrise-io/auth-service)). Companion to the 18 merged PRs in the `bitrise-steplib` org that removed the same pattern from e2e workflows.

**Note:** The integration tests in `./integration` use `BITRISEIO_ABCS_API_URL` and `BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN` (set by the removed workflow). These will need to be provided through a different mechanism — e.g. pipeline env vars or TIS-issued tokens — for `test_integration` to keep working.

## Test plan
- [ ] CI passes (the `test` workflow does not depend on these secrets)
- [ ] Integration tests pass with the new token provisioning mechanism