### PR TITLE
refactor(cache/network): swap go-utils v1/retry → v2/retry

### DIFF
--- a/cache/network/download.go
+++ b/cache/network/download.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/bitrise-io/go-steputils/v2/cache/network/chunkdownloader"
-	"github.com/bitrise-io/go-utils/retry"
 	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-utils/v2/retry"
 	"github.com/bitrise-io/go-utils/v2/retryhttp"
 	"github.com/hashicorp/go-retryablehttp"
 )


### PR DESCRIPTION
## Summary

go-utils/v2 has shipped its own `retry` package as of v2.0.0-alpha.34 with a compatible API (`Times.Wait.TryWithAbort`, `Action`, `AbortableAction`). The `cache/network/download` path was the only retry import in this repo still on the v1 line, so swap to the v2 import.

Part of the long-running v1-deps trim.

### Diff

One-line import change in `cache/network/download.go`:

```diff
-"github.com/bitrise-io/go-utils/retry"
+"github.com/bitrise-io/go-utils/v2/retry"
```

### Remaining v1 import after this PR

`export/export.go` uses `go-utils/ziputil` (no v2 equivalent yet — needs a port or a stdlib `archive/zip` swap). Out of scope for this PR.

### Test plan

- [x] `go test ./cache/network/...` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)