### PR TITLE
chore: migrate command/gems Gemfile.lock helpers to v2 (STEP-2160)

### DIFF
--- a/ruby/gemfile.go
+++ b/ruby/gemfile.go
@@ -1,0 +1,130 @@
+package ruby
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Version contains a gem version
+type Version struct {
+	Version string
+	Found   bool
+}
+
+// ParseVersionFromBundle returns the specified gem version parsed from a Gemfile.lock on a best effort basis, for logging purposes only.
+//
+// for "fastlane" and the following Gemfile.lock example, it returns: ">= 2.0)"
+//
+//	specs:
+//	  CFPropertyList (3.0.0)
+//	  addressable (2.6.0)
+//	    public_suffix (>= 2.0.2, < 4.0)
+//	  atomos (0.1.3)
+//	  babosa (1.0.2)
+//	  badge (0.8.5)
+//	    curb (~> 0.9)
+//	    fastimage (>= 1.6)
+//	    fastlane (>= 2.0)
+//	    mini_magick (>= 4.5)
+//	  claide (1.0.2)
+func ParseVersionFromBundle(gemName string, gemfileLockContent string) (Version, error) {
+	var relevantLines []string
+	lines := strings.Split(gemfileLockContent, "\n")
+
+	specsStart := false
+	for _, line := range lines {
+		if strings.Trim(line, " ") == "" {
+			specsStart = false
+		}
+
+		if strings.Contains(line, "specs:") {
+			specsStart = true
+			continue
+		}
+
+		if specsStart {
+			relevantLines = append(relevantLines, line)
+		}
+	}
+
+	exp := regexp.MustCompile(fmt.Sprintf(`^%s \((.+)\)`, regexp.QuoteMeta(gemName)))
+	for _, line := range relevantLines {
+		match := exp.FindStringSubmatch(strings.TrimSpace(line))
+		if match == nil {
+			continue
+		}
+		if len(match) != 2 {
+			return Version{}, fmt.Errorf("unexpected regexp match: %v", match)
+		}
+		return Version{
+			Version: match[1],
+			Found:   true,
+		}, nil
+	}
+
+	return Version{}, nil
+}
+
+// ParseBundlerVersion returns the bundler version used to create the bundle
+func ParseBundlerVersion(gemfileLockContent string) (Version, error) {
+	bundlerRegexp := regexp.MustCompile(`(?m)^BUNDLED WITH\n\s+(\S+)`)
+	match := bundlerRegexp.FindStringSubmatch(gemfileLockContent)
+	if match == nil {
+		return Version{}, nil
+	}
+	if len(match) != 2 {
+		return Version{}, fmt.Errorf("unexpected regexp match: %v", match)
+	}
+
+	return Version{
+		Version: match[1],
+		Found:   true,
+	}, nil
+}
+
+var (
+	gemFileLockNames = []string{"Gemfile.lock", "gems.locked"}
+	// ErrGemLockNotFound is returned when no gem lock file is found in the search dir.
+	ErrGemLockNotFound = errors.New("gem lock file not found")
+)
+
+// GemFileLockPth gets the path for the gem lock file from the given directory.
+func GemFileLockPth(searchDir string) (string, error) {
+	for _, gemFileName := range gemFileLockNames {
+		pth := filepath.Join(searchDir, gemFileName)
+		if _, err := os.Stat(pth); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return "", err
+		}
+		return pth, nil
+	}
+	return "", ErrGemLockNotFound
+}
+
+// GemFileLockContent gets the content of the gem lock file from the given directory.
+func GemFileLockContent(searchDir string) (string, error) {
+	gemFileLockPth, err := GemFileLockPth(searchDir)
+	if err != nil {
+		return "", err
+	}
+	content, err := os.ReadFile(gemFileLockPth)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}
+
+// ParseVersionFromBundlePth overload for ParseVersionFromBundle.
+func ParseVersionFromBundlePth(gemName string, gemFileLockPth string) (Version, error) {
+	content, err := os.ReadFile(gemFileLockPth)
+	if err != nil {
+		return Version{}, err
+	}
+	return ParseVersionFromBundle(gemName, string(content))
+}

--- a/ruby/gemfile_test.go
+++ b/ruby/gemfile_test.go
@@ -1,0 +1,232 @@
+package ruby
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_ParseVersionFromBundle(t *testing.T) {
+	tests := []struct {
+		name               string
+		gemName            string
+		gemfileLockContent string
+		wantGemVersion     Version
+		wantErr            bool
+	}{
+		{
+			name:               "Parse fastlane version",
+			gemfileLockContent: gemfileLockContent,
+			gemName:            "fastlane",
+			wantGemVersion: Version{
+				Version: "2.13.0",
+				Found:   true,
+			},
+		},
+		{
+			name:               "Bad case which can happen if other gem depends on fastlane, not an issue as the version should only be used for logging.",
+			gemfileLockContent: badFastlaneVersion,
+			gemName:            "fastlane",
+			wantGemVersion: Version{
+				Version: ">= 2.0",
+				Found:   true,
+			},
+		},
+		{
+			name:               "Cocoapods is not a dependency",
+			gemfileLockContent: noCocoapods,
+			gemName:            "cocoapods",
+			wantGemVersion: Version{
+				Found: false,
+			},
+		},
+		{
+			name:               "Cocoapods is a dependency",
+			gemfileLockContent: hasCocoapods,
+			gemName:            "cocoapods",
+			wantGemVersion: Version{
+				Version: "1.0.0",
+				Found:   true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotGemVersion, err := ParseVersionFromBundle(tt.gemName, tt.gemfileLockContent)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseVersionFromBundle() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotGemVersion, tt.wantGemVersion) {
+				t.Errorf("ParseVersionFromBundle() = %v, want %v", gotGemVersion, tt.wantGemVersion)
+			}
+		})
+	}
+}
+
+func Test_ParseBundlerVersion(t *testing.T) {
+	tests := []struct {
+		name               string
+		gemfileLockContent string
+		want               Version
+		wantErr            bool
+	}{
+		{
+			name:               "should match",
+			gemfileLockContent: gemfileLockContent,
+			want: Version{
+				Version: "1.13.6",
+				Found:   true,
+			},
+		},
+		{
+			name: "newline after version",
+			gemfileLockContent: `BUNDLED WITH
+      1.13.6
+
+      `,
+			want: Version{
+				Version: "1.13.6",
+				Found:   true,
+			},
+		},
+		{
+			name: "newline before version",
+			gemfileLockContent: `BUNDLED WITH
+
+      1.13.6`,
+			want: Version{
+				Version: "1.13.6",
+				Found:   true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseBundlerVersion(tt.gemfileLockContent)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseBundlerVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseBundlerVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+const badFastlaneVersion = `GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (3.0.0)
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    atomos (0.1.3)
+    babosa (1.0.2)
+    badge (0.8.5)
+      curb (~> 0.9)
+      fastimage (>= 1.6)
+      fastlane (>= 2.0)
+      mini_magick (>= 4.5)
+    claide (1.0.2)
+    colored (1.2)
+    colored2 (3.1.2)
+    commander-fastlane (4.4.6)
+      highline (~> 1.7.2)
+    curb (0.9.4)
+    declarative (0.0.10)
+    declarative-option (0.1.0)
+    digest-crc (0.4.1)
+    domain_name (0.5.20180417)
+      unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.7.2)
+    emoji_regex (1.0.1)
+    excon (0.62.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    faraday-cookie_jar (0.0.6)
+      faraday (>= 0.7.4)
+      http-cookie (~> 1.0.0)
+    faraday_middleware (0.13.1)
+      faraday (>= 0.7.4, < 1.0)
+    fastimage (2.1.5)
+    fastlane (2.120.0)
+      CFPropertyList (>= 2.3, < 4.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  badge
+  fastlane
+
+BUNDLED WITH
+  1.16.1
+`
+
+const gemfileLockContent = `
+GIT
+  remote: git://xyz.git
+  revision: xyz
+  branch: patch-1
+  specs:
+    fastlane-xyz (1.0.2)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.3.5)
+    activesupport (4.2.7.1)
+      i18n (~> 0.7)
+    cocoapods (1.1.1)
+      activesupport (>= 4.0.2, < 5)
+    fastlane (2.13.0)
+      activesupport (< 5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cocoapods (~> 1.1.0)
+  fastlane (~> 2.0)
+
+BUNDLED WITH
+   1.13.6`
+
+const noCocoapods = `GEM
+remote: https://rubygems.org/
+specs:
+  activesupport (4.2.6)
+    i18n (~> 0.7)
+  claide (1.0.0)
+  fastlane (2.13.0)
+    activesupport (< 5)
+
+PLATFORMS
+ruby
+
+DEPENDENCIES
+fastlane
+
+BUNDLED WITH
+ 1.10.6
+`
+
+const hasCocoapods = `GEM
+remote: https://rubygems.org/
+specs:
+  activesupport (4.2.6)
+    i18n (~> 0.7)
+  cocoapods (1.0.0)
+    activesupport (>= 4.0.2)
+  fastlane (2.13.0)
+    activesupport (< 5)
+
+PLATFORMS
+ruby
+
+DEPENDENCIES
+cocoapods (~> 1.0)
+
+BUNDLED WITH
+ 1.10.6
+`


### PR DESCRIPTION
## Summary

Ports the v1 `command/gems` package's Gemfile.lock parsing helpers into the existing v2 `ruby/` package as a single new `ruby/gemfile.go` (plus its test file). Closes STEP-2160.

## What changed

- **New: `ruby/gemfile.go`** — ports the v1 public surface verbatim:
  - `Version` struct (`Version string`, `Found bool`)
  - `ParseVersionFromBundle(gemName, content string) (Version, error)` — best-effort gem version extraction from a `Gemfile.lock` body, for logging.
  - `ParseBundlerVersion(content string) (Version, error)` — extracts the `BUNDLED WITH` value.
  - `GemFileLockPth(searchDir string) (string, error)` — finds `Gemfile.lock` or `gems.locked`.
  - `GemFileLockContent(searchDir string) (string, error)` — convenience read of the lock file's content.
  - `ParseVersionFromBundlePth(gemName, lockPath string) (Version, error)` — path-based overload.
  - `ErrGemLockNotFound` sentinel.

- **New: `ruby/gemfile_test.go`** — ports the v1 table tests (`Test_ParseVersionFromBundle`, `Test_ParseBundlerVersion`) verbatim. Test fixtures were trimmed where they were duplicating the same `BUNDLED WITH` line under different framing (kept the bodies that actually exercise distinct branches).

- **Dropped: v1's `command/gems/bundler.go`.** Every command-builder it exposed is already covered by `ruby.CommandFactory` on `master`:
  | v1 `command/gems` | v2 `ruby` |
  | --- | --- |
  | `InstallBundlerCommand(Version) *command.Model` | `CommandFactory.CreateGemInstall("bundler", v.Version, ..., opts)` |
  | `BundleInstallCommand(Version) (*command.Model, error)` | `CommandFactory.CreateBundleInstall(v.Version, opts)` |
  | `BundleExecPrefix(Version) []string` | `CommandFactory.CreateBundleExec(name, args, v.Version, opts)` |
  | `RbenvVersionsCommand() *command.Model` | not migrated — used only as a one-shot diagnostic; consumers can switch to `cmdFactory.Create("rbenv", []string{"versions"}, nil)` directly. |

## API change vs v1

`fileutil.ReadStringFromFile` has no v2 equivalent on the new `FileManager`, so file reads switched to stdlib `os.ReadFile` with a `string(content)` conversion at the call site. Returned values and error semantics are unchanged from v1.

## What is preserved

- `Version` struct field names + JSON-free shape — call sites needing to type-assert / map don't break.
- All exported function names, signatures, and the `ErrGemLockNotFound` sentinel — mechanical migration for consumers.
- Both lock file names recognized: `Gemfile.lock` and `gems.locked`.

## Test plan

- [x] `go test ./ruby/...` — all subtests green, including the migrated `Test_ParseVersionFromBundle/{Parse_fastlane_version, Bad_case_*, Cocoapods_is_not_a_dependency, Cocoapods_is_a_dependency}` and `Test_ParseBundlerVersion/{should_match, newline_after_version, newline_before_version}`.
- [x] `go build ./...` — clean.
- [x] `go vet ./...` — clean.
- [x] `revive -config (rule.exported, checkPrivateReceivers)` on the new files — clean.
- [x] `gofmt -l` — clean.

The `legacycache` test that fails on this machine is pre-existing (it shells out to `envman` which isn't on `$PATH` locally); reproduces on `master` too.

Jira: [STEP-2160](https://bitrise.atlassian.net/browse/STEP-2160). Parent: [STEP-2154](https://bitrise.atlassian.net/browse/STEP-2154).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[STEP-2160]: https://bitrise.atlassian.net/browse/STEP-2160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ