### PR TITLE
fix: ACI-5219 clean up downloaded cache archive after restore

### DIFF
--- a/cache/restore.go
+++ b/cache/restore.go
@@ -102,6 +102,10 @@ func (r *restorer) Restore(input RestoreCacheInput) error {
 		}
 		return fmt.Errorf("download failed: %w", err)
 	}
+
+	// On many stacks the temp dir is a tmpfs, so a leftover archive holds RAM for the whole build.
+	defer r.removeDownloadedArchive(result.filePath)
+
 	if result.matchedKey == config.Keys[0] {
 		r.logger.Printf("Exact hit for first key")
 	} else {
@@ -223,6 +227,16 @@ func (r *restorer) download(ctx context.Context, config restoreCacheConfig) (dow
 	r.logger.Debugf("Archive downloaded to %s", downloadPath)
 
 	return downloadResult{filePath: downloadPath, matchedKey: matchedKey}, nil
+}
+
+func (r *restorer) removeDownloadedArchive(archivePath string) {
+	if archivePath == "" {
+		return
+	}
+	dir := filepath.Dir(archivePath)
+	if err := os.RemoveAll(dir); err != nil {
+		r.logger.Warnf("Failed to clean up temporary cache archive %s: %s", dir, err)
+	}
 }
 
 func (r *restorer) exposeCacheHit(result downloadResult, evaluatedKeys []string) error {

--- a/cache/restore_test.go
+++ b/cache/restore_test.go
@@ -1,6 +1,8 @@
 package cache
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"testing"
@@ -8,6 +10,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_ProcessRestoreConfig(t *testing.T) {
@@ -158,6 +161,26 @@ func Test_evaluateKeys(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_removeDownloadedArchive(t *testing.T) {
+	r := &restorer{logger: log.NewLogger()}
+
+	t.Run("removes the archive's temp dir", func(t *testing.T) {
+		dir, err := os.MkdirTemp("", "restore-cache")
+		require.NoError(t, err)
+		archivePath := filepath.Join(dir, "cache-20260101-000000.tzst")
+		require.NoError(t, os.WriteFile(archivePath, []byte("dummy"), 0o644))
+
+		r.removeDownloadedArchive(archivePath)
+
+		_, err = os.Stat(dir)
+		assert.True(t, os.IsNotExist(err), "temp dir should be removed")
+	})
+
+	t.Run("empty path is a no-op", func(t *testing.T) {
+		assert.NotPanics(t, func() { r.removeDownloadedArchive("") })
+	})
 }
 
 func Test_exposeCacheHit(t *testing.T) {


### PR DESCRIPTION
## Problem

The shared cache `Restore` implementation downloads the cache archive into a temp dir (`os.MkdirTemp("", "restore-cache")` → `cache-*.tzst`), extracts it, and **never deletes the downloaded archive**. It lingers in the temp dir for the whole build.

On stacks where `/tmp` is a **RAM-backed tmpfs** (e.g. `ubuntu-resolute-26.04`, 16 GB tmpfs on a 31 GB machine), the leftover restore archive occupies RAM for the whole build, and then the `save-*` step builds its own archive in the same tmpfs alongside it. When the two archives + live build memory cross the tmpfs ceiling, the save step fails with:

```
zstd: error 70 : Write error : cannot write block : No space left on device
```

This already affects customers — found while investigating a report where the restore archive (~7.8 GB) was still resident in `/tmp` while the save archive was being written, together approaching the 16 GB tmpfs ceiling.

## Fix

Delete the downloaded archive as soon as the restore step is done with it. The archive is still read after extraction by `exposeCacheHit` (cache-hit checksum), so removal happens on step exit via a `defer` set up right after a successful download — it runs on every return path, after the checksum.

- New `removeDownloadedArchive` method removes the archive's dedicated temp dir.
- Unit test covers removal + the empty-path no-op.

## Follow-up

Bump this into the important `restore-*` step repos (restore-gradle-cache, restore-cache, restore-npm-cache, restore-spm-cache, …) once released.

Ticket: [ACI-5219](https://bitrise.atlassian.net/browse/ACI-5219)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACI-5219]: https://bitrise.atlassian.net/browse/ACI-5219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ