### PR TITLE
[ACI-5219] Fix nil-pointer panic in chunk downloader (set got Logger)

### DIFF
--- a/cache/network/chunkdownloader/downloader.go
+++ b/cache/network/chunkdownloader/downloader.go
@@ -10,26 +10,18 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/got"
 )
-
-// Logger is a minimal logging interface satisfied by *zap.SugaredLogger,
-// go-utils/v2/log.Logger, and most structured loggers out of the box.
-type Logger interface {
-	Infof(format string, v ...interface{})
-	Warnf(format string, v ...interface{})
-	Debugf(format string, v ...interface{})
-	Errorf(format string, v ...interface{})
-}
 
 // Downloader handles parallel chunked downloads with retry and hung detection.
 type Downloader struct {
 	config Config
-	logger Logger
+	logger log.Logger
 }
 
 // New creates a new Downloader with the given configuration and logger.
-func New(config Config, logger Logger) *Downloader {
+func New(config Config, logger log.Logger) *Downloader {
 	return &Downloader{
 		config: config,
 		logger: logger,
@@ -53,6 +45,8 @@ func (d *Downloader) DownloadFile(ctx context.Context, url, dest string) error {
 
 	dl := got.NewDownload(ctx, url, dest)
 	dl.Client = client
+	// got dereferences dl.Logger without a nil check, so it must be non-nil.
+	dl.Logger = d.logger
 	dl.Concurrency = d.config.Concurrency
 	dl.MaxRetryPerChunk = d.config.MaxRetryPerChunk
 	dl.ChunkRetryThreshold = d.config.ChunkRetryThreshold

--- a/cache/network/chunkdownloader/downloader_test.go
+++ b/cache/network/chunkdownloader/downloader_test.go
@@ -1,0 +1,38 @@
+package chunkdownloader
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/stretchr/testify/require"
+)
+
+// got dereferences dl.Logger without a nil check inside its chunk-download
+// goroutine, so DownloadFile must set it. Before the fix this panicked with a
+// nil pointer dereference on rangeable (chunked) downloads.
+func TestDownloadFile_rangeableDownloadDoesNotPanic(t *testing.T) {
+	content := strings.Repeat("bitrise-build-cache-", 30000) // ~600 KB, chunked
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeContent(w, r, "cache.tzst", time.Time{}, strings.NewReader(content))
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "out.tzst")
+	cfg := DefaultConfig()
+	cfg.Concurrency = 4
+
+	err := New(cfg, log.NewLogger()).DownloadFile(context.Background(), srv.URL, dest)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	require.Equal(t, content, string(got))
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/bitrise-io/go-utils v1.0.13
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34
-	github.com/bitrise-io/got v0.0.0-20240902113940-25f6469d1456
+	github.com/bitrise-io/got v0.0.0-20260223134234-6d4aa9f90a75
 	github.com/bmatcuk/doublestar/v4 v4.6.1
 	github.com/docker/go-units v0.4.0
 	github.com/hashicorp/go-retryablehttp v0.7.7

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/bitrise-io/go-utils v1.0.13 h1:1QENhTS/JlKH9F7+/nB+TtbTcor6jGrE6cQ4CJ
 github.com/bitrise-io/go-utils v1.0.13/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34 h1:xsLfhItfs4SCCAesbv7UtKpldNqievDvtHggSuBI2+w=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
-github.com/bitrise-io/got v0.0.0-20240902113940-25f6469d1456 h1:nnr8l7tIFNx9ESyEOLKeihQMoxmrOohmCMucWTXZM9Y=
-github.com/bitrise-io/got v0.0.0-20240902113940-25f6469d1456/go.mod h1:uBBISwY9ylo62hC1MRHqGxH+VJGHwXR1VJ17QApnG14=
+github.com/bitrise-io/got v0.0.0-20260223134234-6d4aa9f90a75 h1:8yACta0OHcrgMkWSA+wlKfWY/DtjBWOn3KwUmZHlhUY=
+github.com/bitrise-io/got v0.0.0-20260223134234-6d4aa9f90a75/go.mod h1:uBBISwY9ylo62hC1MRHqGxH+VJGHwXR1VJ17QApnG14=
 github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
[ACI-5219](https://bitrise.atlassian.net/browse/ACI-5219)

## Summary

Cache restore panics with a nil-pointer dereference on large (multi-chunk) downloads. `github.com/bitrise-io/got` dereferences `Download.Logger` **without a nil check** at the top of its chunk-download goroutine (`download.go`), but our chunk downloader never set `dl.Logger` — it kept the caller's logger in a private minimal interface and only used it for its own logging. So on any chunked download `dl.Logger` was nil → `SIGSEGV`.

This shipped for the first time in `v2.0.0-alpha.51` (the "Export chunk downloader" work). It was masked in this repo because go.mod pinned an older `got` (`20240902`) whose `dl()` had no such unguarded call, while consumers resolve the newer `got` (`20260223`) via MVS.

## Changes

- `cache/network/chunkdownloader/downloader.go`: set `dl.Logger = d.logger` so got's logger is non-nil (and its debug output is routed through the caller's logger). Store the logger as `go-utils/v2/log.Logger` (the type got requires) instead of the private minimal interface that couldn't be passed through.
- `go.mod` / `go.sum`: bump `github.com/bitrise-io/got` to `20260223…` — the version consumers already resolve — so this module builds and tests against what actually ships, removing the version skew that hid the bug.
- Add `downloader_test.go`: a regression test that downloads a rangeable (chunked) file end-to-end. It panics with the exact `nil pointer dereference` without the fix and passes with it.

## Testing

- `go build ./...`, `go vet ./cache/...`, `go test ./cache/...` — all green.
- Negative check: reverting the one-line fix makes the new test reproduce the CI panic (`SIGSEGV ... addr=0x18`), confirming root cause and coverage.

## Notes for reviewers

Found while bumping the restore-* steps to alpha.51 — their e2e caught this crash on multi-chunk cache downloads (small caches took the single-stream path and passed). After this merges we cut a new tag and re-point the step bumps at it.


[ACI-5219]: https://bitrise.atlassian.net/browse/ACI-5219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ